### PR TITLE
Server validation results on the client

### DIFF
--- a/Source/Bifrost.JavaScript/Bifrost.debug.js
+++ b/Source/Bifrost.JavaScript/Bifrost.debug.js
@@ -52,7 +52,7 @@ Bifrost.hashString = (function() {
 	}
 })();
 
-Bifrost.namespace("Bifrost.validation");
+﻿Bifrost.namespace("Bifrost.validation");
 Bifrost.validation.OptionsNotDefined = function (message) {
     this.prototype = Error.prototype;
     this.name = "OptionsNotDefined";
@@ -100,13 +100,13 @@ Bifrost.validation.MissingExpression = function (message) {
     this.name = "MissingExpression";
     this.message = message || "expression is not specified";
 }
-Bifrost.namespace("Bifrost.validation");
+﻿Bifrost.namespace("Bifrost.validation");
 Bifrost.validation.ruleHandlers = (function () {
     return {
     }
 })();
 
-Bifrost.namespace("Bifrost.validation");
+﻿Bifrost.namespace("Bifrost.validation");
 Bifrost.validation.Rule = (function () {
     function Rule(ruleName, options) {
         var self = this;
@@ -130,7 +130,7 @@ Bifrost.validation.Rule = (function () {
         }
     };
 })();
-Bifrost.namespace("Bifrost.validation");
+﻿Bifrost.namespace("Bifrost.validation");
 Bifrost.validation.Validator = (function () {
     function Validator(options) {
         var self = this;
@@ -196,7 +196,7 @@ Bifrost.validation.Validator = (function () {
     }
 })();
 
-if (typeof ko !== 'undefined') {
+﻿if (typeof ko !== 'undefined') {
     ko.bindingHandlers.validationMessageFor = {
         init: function (element, valueAccessor, allBindingsAccessor, viewModel) {
             var value = valueAccessor();
@@ -218,7 +218,7 @@ if (typeof ko !== 'undefined') {
     };
 }
 
-Bifrost.namespace("Bifrost.validation");
+﻿Bifrost.namespace("Bifrost.validation");
 Bifrost.validation.validationService = (function () {
     return {
         extendAllProperties: function (target) {
@@ -256,14 +256,14 @@ Bifrost.validation.validationService = (function () {
         }
     }
 })();
-Bifrost.namespace("Bifrost.validation.ruleHandlers");
+﻿Bifrost.namespace("Bifrost.validation.ruleHandlers");
 Bifrost.validation.ruleHandlers.required = {
     validate: function (value, options) {
         return !(typeof value == "undefined" || value == "");
     }
 };
 
-Bifrost.namespace("Bifrost.validation.ruleHandlers");
+﻿Bifrost.namespace("Bifrost.validation.ruleHandlers");
 Bifrost.validation.ruleHandlers.minLength = {
     validate: function (value, options) {
         if (typeof options === "undefined" || typeof options.length === "undefined") {
@@ -281,7 +281,7 @@ Bifrost.validation.ruleHandlers.minLength = {
     }
 };
 
-Bifrost.namespace("Bifrost.validation.ruleHandlers");
+﻿Bifrost.namespace("Bifrost.validation.ruleHandlers");
 Bifrost.validation.ruleHandlers.maxLength = {
     validate: function (value, options) {
         if (typeof options === "undefined" || typeof options.length === "undefined") {
@@ -298,7 +298,7 @@ Bifrost.validation.ruleHandlers.maxLength = {
     }
 };
 
-Bifrost.namespace("Bifrost.validation.ruleHandlers");
+﻿Bifrost.namespace("Bifrost.validation.ruleHandlers");
 Bifrost.validation.ruleHandlers.range = {
     isNumber: function (number) {
         return !isNaN(parseFloat(number)) && isFinite(number);
@@ -338,7 +338,7 @@ Bifrost.validation.ruleHandlers.range = {
     }
 };
 
-Bifrost.namespace("Bifrost.validation.ruleHandlers");
+﻿Bifrost.namespace("Bifrost.validation.ruleHandlers");
 Bifrost.validation.ruleHandlers.lessThan = {
     throwIfOptionsUndefined: function (options) {
         if (typeof options === "undefined") {
@@ -367,7 +367,7 @@ Bifrost.validation.ruleHandlers.lessThan = {
     }
 };
 
-Bifrost.namespace("Bifrost.validation.ruleHandlers");
+﻿Bifrost.namespace("Bifrost.validation.ruleHandlers");
 Bifrost.validation.ruleHandlers.greaterThan = {
     throwIfOptionsUndefined: function (options) {
         if (!options || typeof options === "undefined") {
@@ -396,7 +396,7 @@ Bifrost.validation.ruleHandlers.greaterThan = {
     }
 };
 
-Bifrost.namespace("Bifrost.validation.ruleHandlers");
+﻿Bifrost.namespace("Bifrost.validation.ruleHandlers");
 Bifrost.validation.ruleHandlers.email = {
     regex : /^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))$/,
 
@@ -405,7 +405,7 @@ Bifrost.validation.ruleHandlers.email = {
     }
 };
 
-Bifrost.namespace("Bifrost.validation.ruleHandlers");
+﻿Bifrost.namespace("Bifrost.validation.ruleHandlers");
 
 Bifrost.validation.ruleHandlers.regex = {
     throwIfOptionsUndefined: function (options) {
@@ -460,8 +460,8 @@ Bifrost.commands.CommandResult = (function () {
             var commandResult = new CommandResult();
             return commandResult;
         },
-        createFrom: function(json) {
-            var existing = $.parseJSON(json);
+        createFrom: function (result) {
+            var existing = typeof result === "string" ? $.parseJSON(result) : result;
             var commandResult = new CommandResult(existing);
             return commandResult;
         }
@@ -531,22 +531,28 @@ Bifrost.commands.Command = (function (window) {
             }
         };
 
+        this.applyValidationMessageToMembers = function (members, message) {
+            for (var j = 0; j < members.length; j++) {
+                var member = members[j];
+                member = member.charAt(0).toLowerCase() + member.substring(1);
+                if (typeof message === "string" && typeof member === "string") {
+                    if (self.parameters.hasOwnProperty(member)) {
+                        self.parameters[member].validator.isValid(false);
+                        self.parameters[member].validator.message(message);
+                    }
+                }
+            }
+        }
+
         this.applyServerValidation = function (validationResults) {
             for (var i = 0; i < validationResults.length; i++) {
                 var validationResult = validationResults[i];
                 var message = validationResult.errorMessage;
                 var memberNames = validationResult.memberNames;
                 if (memberNames.length > 0) {
-                    for (var j = 0; j < memberNames.length; j++) {
-                        var member = memberNames[j];
-                        if (typeof message === "string" && typeof member === "string") {
-                            if (self.parameters.hasOwnProperty(member)) {
-                                self.parameters[member].validator.isValid(false);
-                                self.parameters[member].validator.message(message);
-                            }
-                        }
-                    }
-                }else {
+                    //one (or more) of the parameters has an error, so apply the error to those
+                    self.applyValidationMessageToMembers(memberNames, message);
+                } else {
                     //the command needs a validator we can apply this message to.
                 }
             }
@@ -650,7 +656,7 @@ Bifrost.commands.commandCoordinator = (function () {
 
     function handleCommandCompletion(jqXHR, command, commandResult) {
         if (jqXHR.status === 200) {
-            command.result = commandResult;
+            command.result = Bifrost.commands.CommandResult.createFrom(commandResult);
             command.hasExecuted = true;
             if (command.result.success === true) {
                 command.onSuccess();

--- a/Source/Bifrost.JavaScript/Commands/Command.js
+++ b/Source/Bifrost.JavaScript/Commands/Command.js
@@ -62,22 +62,28 @@ Bifrost.commands.Command = (function (window) {
             }
         };
 
+        this.applyValidationMessageToMembers = function (members, message) {
+            for (var j = 0; j < members.length; j++) {
+                var member = members[j];
+                member = member.charAt(0).toLowerCase() + member.substring(1);
+                if (typeof message === "string" && typeof member === "string") {
+                    if (self.parameters.hasOwnProperty(member)) {
+                        self.parameters[member].validator.isValid(false);
+                        self.parameters[member].validator.message(message);
+                    }
+                }
+            }
+        }
+
         this.applyServerValidation = function (validationResults) {
             for (var i = 0; i < validationResults.length; i++) {
                 var validationResult = validationResults[i];
                 var message = validationResult.errorMessage;
                 var memberNames = validationResult.memberNames;
                 if (memberNames.length > 0) {
-                    for (var j = 0; j < memberNames.length; j++) {
-                        var member = memberNames[j];
-                        if (typeof message === "string" && typeof member === "string") {
-                            if (self.parameters.hasOwnProperty(member)) {
-                                self.parameters[member].validator.isValid(false);
-                                self.parameters[member].validator.message(message);
-                            }
-                        }
-                    }
-                }else {
+                    //one (or more) of the parameters has an error, so apply the error to those
+                    self.applyValidationMessageToMembers(memberNames, message);
+                } else {
                     //the command needs a validator we can apply this message to.
                 }
             }


### PR DESCRIPTION
validation messages from the server are now applied to the knockout viewmodel. For example, a rating submitted with value 9000 when the allowed values are 1,2,3,4 or 5 will return a commandResult with a validationResult. The error messages in the validationResult are applied to the correct fields in the viewModel and shown in the view if the validationMessageFor knockoutBinding is used.

TODO: show general error messages for the command. Maybe use the Validator on the Command? and a validationMessagesFor custombinding which will foreach the validationResults for the command and show them in a list in the view?
