### PR TITLE
#585 Handle missing properties on target object during mapping.

### DIFF
--- a/Source/Bifrost.JavaScript.Specs/Bifrost.JavaScript.Specs.csproj
+++ b/Source/Bifrost.JavaScript.Specs/Bifrost.JavaScript.Specs.csproj
@@ -96,6 +96,9 @@
     <Content Include="commands\for_hasChanges\when_initial_value_is_set_with_value_on_observable_differing.js" />
     <Content Include="interaction\for_CommandOperation\when_creating_command_of_type_with_command_created_callback.js" />
     <Content Include="interaction\for_CommandOperation\when_creating_command_of_type.js" />
+    <Content Include="mapping\for_mapper\when_mapping_to_instance_with_map_with_objectproperty.js" />
+    <Content Include="mapping\for_mapper\when_mapping_to_instance_with_objectproperty.js" />
+    <Content Include="mapping\for_mapper\when_mapping_to_instance_with_objectproperty_with_missing_objectproperty.js" />
     <Content Include="mapping\for_mapper\when_mapping_to_type_with_map_that_has_propertymap_with_different_target_property_for_given_property.js" />
     <Content Include="mapping\for_mapper\when_mapping_to_instance_with_map_that_has_propertymap_with_different_target_property_for_one_of_the_given_properties.js" />
     <Content Include="mapping\for_mapper\when_mapping_to_instance_with_one_of_two_matching_properties.js" />

--- a/Source/Bifrost.JavaScript.Specs/mapping/for_mapper/when_mapping_to_instance_with_map_with_objectproperty.js
+++ b/Source/Bifrost.JavaScript.Specs/mapping/for_mapper/when_mapping_to_instance_with_map_with_objectproperty.js
@@ -1,0 +1,36 @@
+describe("when mapping to instance with map with objectproperty", function(){
+    var data = { innerData: { integer: 42 } };
+
+    var mapStub = {
+        canMapProperty: function (property) {
+            return property == "innerData";
+        },
+        mapProperty: function(alreadyMapped, from, to) {
+            to.innerData = { mapped: 'yes' };
+        }
+    };
+
+    var parameters = {
+        typeConverters: {
+            convertFrom: sinon.stub().returns(42)
+        },
+        maps: {
+            hasMapFor: sinon.stub().returns(true),
+            getMapFor: sinon.stub().returns(mapStub)
+        }
+    };
+
+    var type = Bifrost.Type.extend(function () {
+    });
+
+    var mappedInstance = type.create();
+
+    (function becauseOf(){
+        var mapper = Bifrost.mapping.mapper.create(parameters);
+        mapper.mapToInstance(type, data, mappedInstance);
+    })();
+
+    it("should map the objectproperty", function () {
+        expect(mappedInstance.innerData.mapped).toBe("yes");
+    });
+});

--- a/Source/Bifrost.JavaScript.Specs/mapping/for_mapper/when_mapping_to_instance_with_objectproperty.js
+++ b/Source/Bifrost.JavaScript.Specs/mapping/for_mapper/when_mapping_to_instance_with_objectproperty.js
@@ -1,0 +1,25 @@
+describe("when mapping to instance with objectproperty", function(){
+    var data = { innerData: { integer: 42 } };
+
+    var parameters = {
+        typeConverters: {
+            convertFrom: sinon.stub().returns(42)
+        },
+        maps: { hasMapFor: sinon.stub().returns(false) }
+    };
+
+    var type = Bifrost.Type.extend(function () {
+        this.innerData = { integer: 0 };
+    });
+
+    var mappedInstance = type.create();
+
+    (function becauseOf(){
+        var mapper = Bifrost.mapping.mapper.create(parameters);
+        mapper.mapToInstance(type, data, mappedInstance);
+    })();
+
+    it("should set the converted value to the objectproperty", function () {
+        expect(mappedInstance.innerData.integer).toBe(42);
+    });
+});

--- a/Source/Bifrost.JavaScript.Specs/mapping/for_mapper/when_mapping_to_instance_with_objectproperty_with_missing_objectproperty.js
+++ b/Source/Bifrost.JavaScript.Specs/mapping/for_mapper/when_mapping_to_instance_with_objectproperty_with_missing_objectproperty.js
@@ -1,0 +1,24 @@
+describe("when mapping to instance with objectproperty with missing objectproperty", function(){
+    var data = { innerData: { integer: 42 } };
+
+    var parameters = {
+        typeConverters: {
+            convertFrom: sinon.stub().returns(42)
+        },
+        maps: { hasMapFor: sinon.stub().returns(false) }
+    };
+
+    var type = Bifrost.Type.extend(function () {
+    });
+
+    var mappedInstance = type.create();
+
+    (function becauseOf(){
+        var mapper = Bifrost.mapping.mapper.create(parameters);
+        mapper.mapToInstance(type, data, mappedInstance);
+    })();
+
+    it("should not create the objectproperty", function () {
+        expect(mappedInstance.innerData).toBeUndefined();
+    });
+});

--- a/Source/Bifrost.JavaScript/mapping/mapper.js
+++ b/Source/Bifrost.JavaScript/mapping/mapper.js
@@ -30,7 +30,7 @@ Bifrost.namespace("Bifrost.mapping", {
 
                 if (!Bifrost.isUndefined(from[property])) {
                     
-                    if (Bifrost.isObject(from[property])) {
+                    if (Bifrost.isObject(from[property]) && Bifrost.isObject(to[property])) {
                         copyProperties(mappedProperties, from[property], to[property]);
                     } else {
                         if (!Bifrost.isNullOrUndefined(map)) {


### PR DESCRIPTION
Mapping rules are as such:
1) If from property doesn't exist: Do nothing
2) If both from property and to property is an object property, recurse into this property (using the same map)
3) If using map, and the map supports this property, call into this map (note that the target property does not exist, and the map is responsible for any recursive behaviour on the source)
4) If the target property exists: Try to map it using normal converter behavior.

(Note that the mappedProperties return value still doesn't distinguish between properties on different levels, say data = { prop: 1, nested: { prop: 2 }} )