### PR TITLE
Upgrade NHibernate dependencies

### DIFF
--- a/Source/Bifrost.NHibernate.Specs/Bifrost.NHibernate.Specs.csproj
+++ b/Source/Bifrost.NHibernate.Specs/Bifrost.NHibernate.Specs.csproj
@@ -36,11 +36,13 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentNHibernate">
-      <HintPath>..\Solutions\packages\FluentNHibernate.1.3.0.717\lib\FluentNHibernate.dll</HintPath>
+    <Reference Include="FluentNHibernate, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Solutions\packages\FluentNHibernate.2.0.1.0\lib\net40\FluentNHibernate.dll</HintPath>
     </Reference>
-    <Reference Include="Iesi.Collections">
-      <HintPath>..\Solutions\packages\Iesi.Collections.3.2.0.4000\lib\Net35\Iesi.Collections.dll</HintPath>
+    <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Solutions\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications, Version=0.9.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -58,8 +60,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Solutions\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate">
-      <HintPath>..\Solutions\packages\NHibernate.3.2.0.4000\lib\Net35\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Solutions\packages\NHibernate.4.0.3.4000\lib\net40\NHibernate.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -80,6 +83,7 @@
     <Compile Include="Read\for_ReadOnlySession\when_getting_the_current_session_multiple_times.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Bifrost.NHibernate.Specs/app.config
+++ b/Source/Bifrost.NHibernate.Specs/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Source/Bifrost.NHibernate.Specs/packages.config
+++ b/Source/Bifrost.NHibernate.Specs/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentNHibernate" version="1.3.0.717" targetFramework="net40" />
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net40" />
+  <package id="FluentNHibernate" version="2.0.1.0" targetFramework="net45" />
+  <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
   <package id="Machine.Specifications" version="0.9.1" targetFramework="net45" />
   <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net45" />
   <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
-  <package id="NHibernate" version="3.2.0.4000" targetFramework="net40" />
+  <package id="NHibernate" version="4.0.3.4000" targetFramework="net45" />
 </packages>

--- a/Source/Bifrost.NHibernate/Bifrost.NHibernate.csproj
+++ b/Source/Bifrost.NHibernate/Bifrost.NHibernate.csproj
@@ -36,10 +36,22 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Keys\Bifrost.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentNHibernate, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Solutions\packages\FluentNHibernate.2.0.1.0\lib\net40\FluentNHibernate.dll</HintPath>
+    </Reference>
+    <Reference Include="Iesi.Collections, Version=4.0.0.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Solutions\packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
+    </Reference>
+    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\Solutions\packages\NHibernate.4.0.3.4000\lib\net40\NHibernate.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -47,15 +59,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="FluentNHibernate">
-      <HintPath>..\Solutions\packages\FluentNHibernate.1.3.0.717\lib\FluentNHibernate.dll</HintPath>
-    </Reference>
-    <Reference Include="Iesi.Collections, Version=1.0.1.0, Culture=neutral, PublicKeyToken=aa95f207798dfdb4">
-      <HintPath>..\Solutions\packages\Iesi.Collections.3.2.0.4000\lib\Net35\Iesi.Collections.dll</HintPath>
-    </Reference>
-    <Reference Include="NHibernate">
-      <HintPath>..\Solutions\packages\NHibernate.3.2.0.4000\lib\Net35\NHibernate.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Common\CommonAssemblyInfo.cs">
@@ -102,6 +105,7 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Bifrost.NHibernate.nuspec" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/Source/Bifrost.NHibernate/Read/ReadOnlySessionProxy.cs
+++ b/Source/Bifrost.NHibernate/Read/ReadOnlySessionProxy.cs
@@ -398,6 +398,11 @@ namespace Bifrost.NHibernate.Read
             throw new NotSupportedException(NOT_ALLOWED);
         }
 
+        public void Save(string entityName, object obj, object id)
+        {
+            throw new NotSupportedException(NOT_ALLOWED);
+        }
+
         public void Save(object obj, object id)
         {
             throw new NotSupportedException(NOT_ALLOWED);
@@ -413,6 +418,11 @@ namespace Bifrost.NHibernate.Read
             throw new NotSupportedException(NOT_ALLOWED);
         }
 
+        public void SaveOrUpdate(string entityName, object obj, object id)
+        {
+            throw new NotSupportedException(NOT_ALLOWED);
+        }
+
         public void SaveOrUpdate(object obj)
         {
             throw new NotSupportedException(NOT_ALLOWED);
@@ -424,6 +434,11 @@ namespace Bifrost.NHibernate.Read
         }
 
         public object SaveOrUpdateCopy(object obj)
+        {
+            throw new NotSupportedException(NOT_ALLOWED);
+        }
+
+        public void Update(string entityName, object obj, object id)
         {
             throw new NotSupportedException(NOT_ALLOWED);
         }

--- a/Source/Bifrost.NHibernate/app.config
+++ b/Source/Bifrost.NHibernate/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="NHibernate" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.4000" newVersion="4.0.0.4000" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Iesi.Collections" publicKeyToken="aa95f207798dfdb4" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Source/Bifrost.NHibernate/packages.config
+++ b/Source/Bifrost.NHibernate/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentNHibernate" version="1.3.0.717" targetFramework="net40" />
-  <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net40" />
-  <package id="NHibernate" version="3.2.0.4000" targetFramework="net40" />
+  <package id="FluentNHibernate" version="2.0.1.0" targetFramework="net45" />
+  <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
+  <package id="NHibernate" version="4.0.3.4000" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
FluentNHibernate: 1.3.0.717 -> 2.0.1.0
Iesi.Collections: 3.2.0.4000 -> 4.0.1.4000
NHibernate: 3.2.0.4000 -> 4.0.3.4000

Since FluentNHibernate 2.0.1.0 is not signed (https://github.com/jagregory/fluent-nhibernate/issues/295) Bifrost.NHibernate will not be signed.