### PR TITLE
Bifrost issue 646: Only resolve dependency instances when needed.

### DIFF
--- a/Source/Bifrost.JavaScript/Bifrost.debug.js
+++ b/Source/Bifrost.JavaScript/Bifrost.debug.js
@@ -1609,7 +1609,6 @@ Bifrost.namespace("Bifrost", {
             actualType.prototype = this._super.create(instanceHash, true);
         }
         addMissingDependenciesAsNullFromTypeDefinition(instanceHash, this);
-        var dependencyInstances = resolveDependencyInstances(instanceHash, this);
         var scope = null;
         if( this !== Bifrost.Type ) {
             this.instancesPerScope = this.instancesPerScope || {};
@@ -1622,6 +1621,7 @@ Bifrost.namespace("Bifrost", {
 
         var instance = null;
         if( typeof this.createFunction !== "undefined" ) {
+            var dependencyInstances = resolveDependencyInstances(instanceHash, this);
             instance = this.createFunction(this, dependencyInstances);
         } else {
             instance = new actualType();    

--- a/Source/Bifrost.JavaScript/utils/Type.js
+++ b/Source/Bifrost.JavaScript/utils/Type.js
@@ -296,7 +296,6 @@ Bifrost.namespace("Bifrost", {
             actualType.prototype = this._super.create(instanceHash, true);
         }
         addMissingDependenciesAsNullFromTypeDefinition(instanceHash, this);
-        var dependencyInstances = resolveDependencyInstances(instanceHash, this);
         var scope = null;
         if( this !== Bifrost.Type ) {
             this.instancesPerScope = this.instancesPerScope || {};
@@ -309,6 +308,7 @@ Bifrost.namespace("Bifrost", {
 
         var instance = null;
         if( typeof this.createFunction !== "undefined" ) {
+            var dependencyInstances = resolveDependencyInstances(instanceHash, this);
             instance = this.createFunction(this, dependencyInstances);
         } else {
             instance = new actualType();    


### PR DESCRIPTION
Found this lying around. Not a serious issue, but definitively a bug, as singleton dependencies are created each time instances of a singleton are asked for.