### PR TITLE
Use LocalPath in FileSystemAsssemblyProvider to avoid url encoding of…

### DIFF
--- a/Source/Bifrost/Execution/FileSystemAssemblyProvider.cs
+++ b/Source/Bifrost/Execution/FileSystemAssemblyProvider.cs
@@ -40,7 +40,7 @@ namespace Bifrost.Execution
             var codeBase = typeof(FileSystemAssemblyProvider).Assembly.GetName().CodeBase;
             var uri = new Uri(codeBase);
 
-            var assemblyFileInfo = new FileInfo(uri.AbsolutePath);
+            var assemblyFileInfo = new FileInfo(uri.LocalPath);
 
             var assemblyFiles = fileSystem.GetFilesFrom(assemblyFileInfo.Directory.ToString(), "*.dll").ToList();
             assemblyFiles.AddRange(fileSystem.GetFilesFrom(assemblyFileInfo.Directory.ToString(), "*.exe"));


### PR DESCRIPTION
… file paths.

..Fixing issue 662