### PR TITLE
Fix serialization caching bug by following Newtonsoft's recommendation of managing caching yourself.

### DIFF
--- a/Source/Bifrost.DocumentDB/Events/EventStore.cs
+++ b/Source/Bifrost.DocumentDB/Events/EventStore.cs
@@ -71,7 +71,7 @@ namespace Bifrost.DocumentDB.Events
 
             foreach( var @event in uncommittedEventStream )
             {
-                var serialized = _serializer.ToJson(@event, SerializationExtensions.SerializationOptions);
+                var serialized = _serializer.ToJson(@event, SerializationExtensions.CamelCaseOptions);
                 _client
                     .ExecuteStoredProcedureAsync<long>(_insertEventStoredProcedure.SelfLink, serialized)
                     .ContinueWith(t => @event.Id = t.Result)

--- a/Source/Bifrost.DocumentDB/Events/EventSubscriptions.cs
+++ b/Source/Bifrost.DocumentDB/Events/EventSubscriptions.cs
@@ -69,7 +69,7 @@ namespace Bifrost.DocumentDB.Events
                 .CreateDocumentQuery(_collection.SelfLink).Where(d => d.Id == subscription.Id.ToString()).ToArray()
                 .SingleOrDefault(d => d.Id == subscription.Id.ToString());
 
-            using (var stream = _serializer.ToJsonStream(subscription, SerializationExtensions.SerializationOptions))
+            using (var stream = _serializer.ToJsonStream(subscription, SerializationExtensions.CamelCaseOptions))
             {
                 if (document != null)
                 {

--- a/Source/Bifrost.DocumentDB/Events/SerializationExtensions.cs
+++ b/Source/Bifrost.DocumentDB/Events/SerializationExtensions.cs
@@ -30,7 +30,7 @@ namespace Bifrost.DocumentDB.Events
     /// </summary>
     public static class SerializationExtensions
     {
-        internal static SerializationOptions SerializationOptions = new SerializationOptions { UseCamelCase = true };
+        internal static ISerializationOptions CamelCaseOptions = SerializationOptions.CamelCase;
 
         /// <summary>
         /// Deserialize from a document
@@ -45,7 +45,7 @@ namespace Bifrost.DocumentDB.Events
             stream.Position = 0;
             var reader = new StreamReader(stream);
             var jsonAsString = reader.ReadToEnd();
-            var deserialized = (T)serializer.FromJson(typeof(T), jsonAsString, SerializationOptions);
+            var deserialized = (T)serializer.FromJson(typeof(T), jsonAsString, CamelCaseOptions);
             return deserialized;
         }
     }

--- a/Source/Bifrost.JSON.Specs/Bifrost.JSON.Specs.csproj
+++ b/Source/Bifrost.JSON.Specs/Bifrost.JSON.Specs.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Serialization\for_Serializer\when_deserializing_type_with_an_interface_property_and_json_contains_type_reference.cs" />
     <Compile Include="Serialization\for_Serializer\when_deserialzing_a_type_with_concepts.cs" />
     <Compile Include="Serialization\for_Serializer\when_deserialzing_a_type_with_nested_concepts.cs" />
+    <Compile Include="Serialization\for_Serializer\when_serializing_a_dictionary.cs" />
     <Compile Include="Serialization\for_Serializer\when_serializing_a_concept.cs" />
     <Compile Include="Serialization\for_Serializer\when_serializing_type_with_an_interface_property_and_instance_set_to_implementation.cs" />
     <Compile Include="Serialization\for_SerializerContractResolver\given\a_saga_contract_resolver.cs" />

--- a/Source/Bifrost.JSON.Specs/Serialization/for_Serializer/when_serializing_a_dictionary.cs
+++ b/Source/Bifrost.JSON.Specs/Serialization/for_Serializer/when_serializing_a_dictionary.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using Bifrost.JSON.Serialization;
+using Bifrost.Serialization;
+using Machine.Specifications;
+
+namespace Bifrost.JSON.Specs.Serialization.for_Serializer
+{
+    [Subject(typeof (Serializer))]
+    public class when_serializing_a_dictionary : given.a_serializer
+    {
+        static IDictionary<string, string> to_serialize;
+        static string serialized_version;
+        static string serialized_version_camel_case;
+
+        Establish context = () =>
+        {
+            to_serialize = new Dictionary<string, string>
+            {
+                {"Key1", "Value1"},
+                {"Key2", "Value2"},
+            };
+        };
+
+        Because of = () =>
+        {
+            serialized_version = serializer.ToJson(to_serialize);
+            serialized_version_camel_case = serializer.ToJson(to_serialize, SerializationOptions.CamelCase);
+        };
+
+        It should_serialize_the_dictionary = () =>
+            serialized_version.ShouldEqual("{\"Key1\":\"Value1\",\"Key2\":\"Value2\"}");
+
+        It should_serialize_the_dictionary_in_camel_case = () =>
+            serialized_version_camel_case.ShouldEqual("{\"key1\":\"Value1\",\"key2\":\"Value2\"}");
+    }
+}

--- a/Source/Bifrost.JSON.Specs/Serialization/for_SerializerContractResolver/given/a_saga_contract_resolver.cs
+++ b/Source/Bifrost.JSON.Specs/Serialization/for_SerializerContractResolver/given/a_saga_contract_resolver.cs
@@ -1,8 +1,6 @@
-﻿using System.Linq;
-using Bifrost.Execution;
-using Bifrost.Sagas;
-using Bifrost.Serialization;
+﻿using Bifrost.Execution;
 using Bifrost.JSON.Serialization;
+using Bifrost.Sagas;
 using Machine.Specifications;
 using Moq;
 
@@ -10,27 +8,13 @@ namespace Bifrost.JSON.Specs.Serialization.for_SerializerContractResolver.given
 {
 	public class a_serializer_contract_resolver_that_ignores_saga_properties
 	{
-		static readonly string[] SagaProperties = typeof(ISaga).GetProperties().Select(t => t.Name).ToArray();
-
-		static readonly SerializationOptions serialization_options =
-			new SerializationOptions
-			{
-				ShouldSerializeProperty = (t, p) =>
-				{
-					if (typeof(ISaga).IsAssignableFrom(t))
-						return !SagaProperties.Any(sp => sp == p);
-
-					return true;
-				}
-			};
-
 		protected static SerializerContractResolver contract_resolver;
 		protected static Mock<IContainer> container_mock;
 
 		Establish context = () =>
 		                    	{
 									container_mock = new Mock<IContainer>();
-		                    		contract_resolver = new SerializerContractResolver(container_mock.Object, serialization_options);
+		                    		contract_resolver = new SerializerContractResolver(container_mock.Object, new SagaSerializationOptions());
 		                    	};
 	}
 }

--- a/Source/Bifrost.JSON/Serialization/SerializerContractResolver.cs
+++ b/Source/Bifrost.JSON/Serialization/SerializerContractResolver.cs
@@ -35,14 +35,14 @@ namespace Bifrost.JSON.Serialization
     {
 
         readonly IContainer _container;
-		readonly SerializationOptions _options;
+		readonly ISerializationOptions _options;
 
         /// <summary>
         /// Initializes a new instance of <see cref="SerializerContractResolver"/>
         /// </summary>
         /// <param name="container">A <see cref="IContainer"/> to use for creating instances of types</param>
-        /// <param name="options"><see cref="SerializationOptions"/> to use during resolving</param>
-		public SerializerContractResolver(IContainer container, SerializationOptions options) : base(true)
+        /// <param name="options"><see cref="ISerializationOptions"/> to use during resolving</param>
+		public SerializerContractResolver(IContainer container, ISerializationOptions options)
 		{
 			_container = container;
 			_options = options;
@@ -95,8 +95,11 @@ namespace Bifrost.JSON.Serialization
         protected override string ResolvePropertyName(string propertyName)
         {
             var result = base.ResolvePropertyName(propertyName);
-            if (_options != null && _options.UseCamelCase)
+            if (_options != null && _options.Flags.HasFlag(SerializationOptionsFlags.UseCamelCase))
+            {
                 result = result.ToCamelCase();
+            }
+
             return result;
         }
 #pragma warning restore 1591 // Xml Comments

--- a/Source/Bifrost.NHibernate.Specs/Events/for_EventConverter/when_converting_to_an_event_holder.cs
+++ b/Source/Bifrost.NHibernate.Specs/Events/for_EventConverter/when_converting_to_an_event_holder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using Bifrost.Testing.Fakes.Events;
 using Bifrost.NHibernate.Events;
-using Bifrost.Serialization;
+using Bifrost.Testing.Fakes.Events;
 using Machine.Specifications;
 
 namespace Bifrost.NHibernate.Specs.Events.for_EventConverter
@@ -26,6 +25,6 @@ namespace Bifrost.NHibernate.Specs.Events.for_EventConverter
         It should_have_the_same_aggregate_id = () => holder.AggregateId.ShouldEqual(aggregate_id);
         It should_have_the_same_caused_by = () => holder.CausedBy.ShouldEqual(caused_by);
         It should_have_the_same_origin = () => holder.Origin.ShouldEqual(origin);
-        It should_serialize_the_event = () => serializer_mock.Verify(s => s.ToJson(@event, Moq.It.IsAny<SerializationOptions>()), Moq.Times.Once());
+        It should_serialize_the_event = () => serializer_mock.Verify(s => s.ToJson(@event), Moq.Times.Once());
     }
 }

--- a/Source/Bifrost.Silverlight/Bifrost.Silverlight.csproj
+++ b/Source/Bifrost.Silverlight/Bifrost.Silverlight.csproj
@@ -905,8 +905,8 @@
     <Compile Include="..\Bifrost\Serialization\SerializationOptions.cs">
       <Link>Serialization\SerializationOptions.cs</Link>
     </Compile>
-    <Compile Include="..\Bifrost\Serialization\SerializationOptionsFlags.cs">
-      <Link>Serialization\SerializationOptionsFlags.cs</Link>
+    <Compile Include="..\Bifrost\Serialization\SerializationOptionFlags.cs">
+      <Link>Serialization\SerializationOptionFlags.cs</Link>
     </Compile>
     <Compile Include="..\Bifrost\Specifications\And.cs">
       <Link>Specifications\And.cs</Link>

--- a/Source/Bifrost.Silverlight/Bifrost.Silverlight.csproj
+++ b/Source/Bifrost.Silverlight/Bifrost.Silverlight.csproj
@@ -704,6 +704,9 @@
     <Compile Include="..\Bifrost\Sagas\Chapter.cs">
       <Link>Sagas\Chapter.cs</Link>
     </Compile>
+    <Compile Include="..\Bifrost\Sagas\SagaSerializationOptions.cs">
+      <Link>Sagas\SagaSerializationOptions.cs</Link>
+    </Compile>
     <Compile Include="..\Bifrost\Sagas\ChapterAlreadyExistException.cs">
       <Link>Sagas\ChapterAlreadyExistException.cs</Link>
     </Compile>
@@ -896,8 +899,14 @@
     <Compile Include="..\Bifrost\Serialization\ISerializer.cs">
       <Link>Serialization\ISerializer.cs</Link>
     </Compile>
+    <Compile Include="..\Bifrost\Serialization\ISerializationOptions.cs">
+      <Link>Serialization\ISerializationOptions.cs</Link>
+    </Compile>
     <Compile Include="..\Bifrost\Serialization\SerializationOptions.cs">
       <Link>Serialization\SerializationOptions.cs</Link>
+    </Compile>
+    <Compile Include="..\Bifrost\Serialization\SerializationOptionsFlags.cs">
+      <Link>Serialization\SerializationOptionsFlags.cs</Link>
     </Compile>
     <Compile Include="..\Bifrost\Specifications\And.cs">
       <Link>Specifications\And.cs</Link>

--- a/Source/Bifrost.Specs/Sagas/for_SagaConverter/given/a_saga_converter_and_a_saga_holder_with_one_chapter_and_one_event_and_chapter_is_current_and_state_is_continuing.cs
+++ b/Source/Bifrost.Specs/Sagas/for_SagaConverter/given/a_saga_converter_and_a_saga_holder_with_one_chapter_and_one_event_and_chapter_is_current_and_state_is_continuing.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using Bifrost.Events;
 using Bifrost.Execution;
-using Bifrost.Testing.Fakes.Events;
-using Bifrost.Testing.Fakes.Sagas;
 using Bifrost.Sagas;
 using Bifrost.Serialization;
+using Bifrost.Testing.Fakes.Events;
+using Bifrost.Testing.Fakes.Sagas;
 using Machine.Specifications;
 using Moq;
 
@@ -51,12 +50,11 @@ namespace Bifrost.Specs.Sagas.for_SagaConverter.given
 		                    		expected_saga = new SagaWithOneChapterProperty();
 
 		                    		container_mock.Setup(c => c.Get(typeof (SagaWithOneChapterProperty))).Returns(expected_saga);
-									serializer_mock.Setup(s => s.FromJson(typeof(SagaWithOneChapterProperty), Moq.It.IsAny<string>(), Moq.It.IsAny<SerializationOptions>())).Returns(expected_saga);
+									serializer_mock.Setup(s => s.FromJson(typeof(SagaWithOneChapterProperty), Moq.It.IsAny<string>(), Moq.It.IsAny<SagaSerializationOptions>())).Returns(expected_saga);
 		                    		serializer_mock.Setup(
 		                    			s =>
-		                    			s.FromJson(Moq.It.IsAny<List<ChapterHolder>>(), Moq.It.IsAny<string>(),
-		                    			           Moq.It.IsAny<SerializationOptions>())).Callback(
-		                    			           	(object obj, string json, SerializationOptions o) =>
+		                    			s.FromJson(Moq.It.IsAny<List<ChapterHolder>>(), Moq.It.IsAny<string>())).Callback(
+		                    			           	(object obj, string json) =>
 		                    			           	((List<ChapterHolder>)obj).Add(chapter_holder));
 		                    		container_mock.Setup(c => c.Get(typeof (SimpleChapter))).Returns(new SimpleChapter());
 

--- a/Source/Bifrost.Specs/Sagas/for_SagaConverter/when_converting_a_saga_with_one_event_to_a_saga_holder.cs
+++ b/Source/Bifrost.Specs/Sagas/for_SagaConverter/when_converting_a_saga_with_one_event_to_a_saga_holder.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using Bifrost.Events;
 using Bifrost.Sagas;
-using Bifrost.Serialization;
 using Machine.Specifications;
 
 namespace Bifrost.Specs.Sagas.for_SagaConverter
@@ -12,6 +11,6 @@ namespace Bifrost.Specs.Sagas.for_SagaConverter
 
 		Because of = () => saga_holder = saga_converter.ToSagaHolder(saga);
 
-		It should_serialize_uncommitted_events = () => serializer_mock.Verify(s=>s.ToJson(Moq.It.IsAny<IEnumerable<IEvent>>(), Moq.It.IsAny<SerializationOptions>()));
+		It should_serialize_uncommitted_events = () => serializer_mock.Verify(s=>s.ToJson(Moq.It.IsAny<IEnumerable<IEvent>>()));
 	}
 }

--- a/Source/Bifrost.Specs/Sagas/for_SagaConverter/when_converting_to_saga.cs
+++ b/Source/Bifrost.Specs/Sagas/for_SagaConverter/when_converting_to_saga.cs
@@ -1,8 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Bifrost.Testing.Fakes.Sagas;
 using Bifrost.Sagas;
-using Bifrost.Serialization;
+using Bifrost.Testing.Fakes.Sagas;
 using Machine.Specifications;
 
 namespace Bifrost.Specs.Sagas.for_SagaConverter
@@ -15,8 +14,8 @@ namespace Bifrost.Specs.Sagas.for_SagaConverter
 
 		It should_not_be_null = () => saga.ShouldNotBeNull();
         It should_be_correct_saga_type = () => saga.ShouldBeOfExactType<SagaWithOneChapterProperty>();
-		It should_deserialize_saga = () => serializer_mock.Verify(s => s.FromJson(typeof(SagaWithOneChapterProperty), Moq.It.IsAny<string>(), Moq.It.IsAny<SerializationOptions>()));
-		It should_deserialize_chapter = () => serializer_mock.Verify(s => s.FromJson(Moq.It.IsAny<List<ChapterHolder>>(), Moq.It.IsAny<string>(), Moq.It.IsAny<SerializationOptions>()));
+		It should_deserialize_saga = () => serializer_mock.Verify(s => s.FromJson(typeof(SagaWithOneChapterProperty), Moq.It.IsAny<string>(), Moq.It.IsAny<SagaSerializationOptions>()));
+		It should_deserialize_chapter = () => serializer_mock.Verify(s => s.FromJson(Moq.It.IsAny<List<ChapterHolder>>(), Moq.It.IsAny<string>()));
 		It should_have_one_chapter_in_saga = () => saga.Chapters.Count().ShouldEqual(1);
 		It should_have_a_simple_chapter = () => saga.Chapters.First().ShouldBeOfExactType<SimpleChapter>();
 		It should_set_current_chapter = () => saga.CurrentChapter.ShouldNotBeNull();

--- a/Source/Bifrost.Specs/Sagas/for_SagaConverter/when_converting_to_saga_holder_with_one_chapter_and_it_is_current.cs
+++ b/Source/Bifrost.Specs/Sagas/for_SagaConverter/when_converting_to_saga_holder_with_one_chapter_and_it_is_current.cs
@@ -1,8 +1,5 @@
-﻿using System.Collections.Generic;
-using Bifrost.Events;
+﻿using Bifrost.Sagas;
 using Bifrost.Testing.Fakes.Sagas;
-using Bifrost.Sagas;
-using Bifrost.Serialization;
 using Machine.Specifications;
 
 namespace Bifrost.Specs.Sagas.for_SagaConverter
@@ -15,6 +12,6 @@ namespace Bifrost.Specs.Sagas.for_SagaConverter
 		It should_set_current_chapter_type = () => saga_holder.CurrentChapterType.ShouldEqual(typeof (SimpleChapter).AssemblyQualifiedName);
 		It should_set_the_id = () => saga_holder.Id.ShouldEqual(saga.Id);
 		It should_set_the_type = () => saga_holder.Type = typeof (SagaWithOneChapterProperty).AssemblyQualifiedName;
-		It should_serialize_saga = () => serializer_mock.Verify(s=>s.ToJson(saga, Moq.It.IsAny<SerializationOptions>()));
+		It should_serialize_saga = () => serializer_mock.Verify(s=>s.ToJson(saga, Moq.It.IsAny<SagaSerializationOptions>()));
 	}
 }

--- a/Source/Bifrost.Web.Mvc.Specs/for_BifrostTempDataProvider/when_loading_temp_data_with_temp_data_in_session.cs
+++ b/Source/Bifrost.Web.Mvc.Specs/for_BifrostTempDataProvider/when_loading_temp_data_with_temp_data_in_session.cs
@@ -29,7 +29,7 @@ namespace Bifrost.Web.Mvc.Specs.for_BifrostTempDataProvider
                                     http_context_mock.SetupGet(hc => hc.Session).Returns(http_session_mock.Object);
                                     controller_context_mock = new Mock<ControllerContext>();
                                     controller_context_mock.SetupGet(cc => cc.HttpContext).Returns(http_context_mock.Object);
-                                    serializer_mock.Setup(s => s.FromJson<Dictionary<string, object>>(serialized_temp_data, Moq.It.IsAny<SerializationOptions>())).Returns(temp_data_dictionary);
+                                    serializer_mock.Setup(s => s.FromJson<Dictionary<string, object>>(serialized_temp_data, SerializationOptions.IncludeTypeNames)).Returns(temp_data_dictionary);
                                 };
 
         Because of = () => temp_data =  temp_data_provider.LoadTempData(controller_context_mock.Object);

--- a/Source/Bifrost.Web.Mvc.Specs/for_BifrostTempDataProvider/when_saving_temp_data_with_temp_data_values.cs
+++ b/Source/Bifrost.Web.Mvc.Specs/for_BifrostTempDataProvider/when_saving_temp_data_with_temp_data_values.cs
@@ -28,7 +28,7 @@ namespace Bifrost.Web.Mvc.Specs.for_BifrostTempDataProvider
                                     http_context_mock.SetupGet(hc => hc.Session).Returns(http_session_mock.Object);
                                     controller_context_mock = new Mock<ControllerContext>();
                                     controller_context_mock.SetupGet(cc => cc.HttpContext).Returns(http_context_mock.Object);
-                                    serializer_mock.Setup(s => s.ToJson(temp_data_dictionary, Moq.It.IsAny<SerializationOptions>())).Returns(serialized_temp_data);
+                                    serializer_mock.Setup(s => s.ToJson(temp_data_dictionary, SerializationOptions.IncludeTypeNames)).Returns(serialized_temp_data);
                                 };
 
         Because of = () => temp_data_provider.SaveTempData(controller_context_mock.Object, temp_data_dictionary);

--- a/Source/Bifrost.Web.Mvc/BifrostTempDataProvider.cs
+++ b/Source/Bifrost.Web.Mvc/BifrostTempDataProvider.cs
@@ -68,8 +68,7 @@ namespace Bifrost.Web.Mvc
             if (serializedTempData == null)
                 return new Dictionary<string, object>();
 
-            return _serializer.FromJson<Dictionary<string, object>>(serializedTempData,
-                                                                    new SerializationOptions {IncludeTypeNames = true});
+            return _serializer.FromJson<Dictionary<string, object>>(serializedTempData, SerializationOptions.IncludeTypeNames);
         }
 
         public void SaveTempData(ControllerContext controllerContext, IDictionary<string, object> values)
@@ -95,7 +94,7 @@ namespace Bifrost.Web.Mvc
 
             if (hasValues)
             {
-                var serializedTempData = _serializer.ToJson(values, new SerializationOptions {IncludeTypeNames = true});
+                var serializedTempData = _serializer.ToJson(values, SerializationOptions.IncludeTypeNames);
                 session[TEMP_DATA_SESSION_STATE_KEY] = serializedTempData;
                 return;
             }

--- a/Source/Bifrost.Web.Specs/Services/for_RestServiceMethodInvoker/when_invoking_a_method_without_parameters_but_returns_complex_type.cs
+++ b/Source/Bifrost.Web.Specs/Services/for_RestServiceMethodInvoker/when_invoking_a_method_without_parameters_but_returns_complex_type.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using Bifrost.Serialization;
 using Machine.Specifications;
 using It = Machine.Specifications.It;
-using Bifrost.Serialization;
 
 namespace Bifrost.Web.Specs.Services.for_RestServiceMethodInvoker
 {
@@ -29,7 +29,7 @@ namespace Bifrost.Web.Specs.Services.for_RestServiceMethodInvoker
                 DoubleValue = expected_double
             };
             service_instance.NoInputComplexOutputReturn = expected_result;
-            serializer_mock.Setup(s => s.ToJson(expected_result, Moq.It.IsAny<SerializationOptions>())).Returns(json);
+            serializer_mock.Setup(s => s.ToJson(expected_result, SerializationOptions.CamelCase)).Returns(json);
         };
 
         Because of = () => result = invoker.Invoke(base_url, service_instance, uri, parameters);

--- a/Source/Bifrost.Web/Services/RestServiceMethodInvoker.cs
+++ b/Source/Bifrost.Web/Services/RestServiceMethodInvoker.cs
@@ -19,12 +19,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Bifrost.Concepts;
 using Bifrost.Extensions;
 using Bifrost.Serialization;
-using System.ComponentModel;
 
 namespace Bifrost.Web.Services
 {
@@ -55,7 +55,7 @@ namespace Bifrost.Web.Services
             var values = GetParameterValues(inputParameters, method);
             var result = method.Invoke(instance, values);
 
-            var serializedResult = _serializer.ToJson(result, new SerializationOptions { UseCamelCase = true });
+            var serializedResult = _serializer.ToJson(result, SerializationOptions.CamelCase);
 
             serializedResult = _jsonInterceptor.Intercept(serializedResult);
 

--- a/Source/Bifrost/Bifrost.csproj
+++ b/Source/Bifrost/Bifrost.csproj
@@ -342,6 +342,9 @@
     <Compile Include="Rules\RuleContext.cs" />
     <Compile Include="Rules\RuleContextFail.cs" />
     <Compile Include="Rules\RuleContexts.cs" />
+    <Compile Include="Sagas\SagaSerializationOptions.cs" />
+    <Compile Include="Serialization\ISerializationOptions.cs" />
+    <Compile Include="Serialization\SerializationOptionFlags.cs" />
     <Compile Include="Specifications\And.cs" />
     <Compile Include="Specifications\CompositeRule.cs" />
     <Compile Include="Specifications\Is.cs" />

--- a/Source/Bifrost/Sagas/SagaSerializationOptions.cs
+++ b/Source/Bifrost/Sagas/SagaSerializationOptions.cs
@@ -1,0 +1,69 @@
+﻿#region License
+
+//
+// Copyright (c) 2008-2015, Dolittle (http://www.dolittle.com)
+//
+// Licensed under the MIT License (http://opensource.org/licenses/MIT)
+//
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the license at 
+//
+//   http://github.com/dolittle/Bifrost/blob/master/MIT-LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#endregion
+
+using System;
+using System.Linq;
+using Bifrost.Serialization;
+
+#if(NETFX_CORE)
+using System.Reflection;
+#endif
+
+namespace Bifrost.Sagas
+{
+    /// <summary>
+    /// Represents the options for serialization
+    /// </summary>
+    public class SagaSerializationOptions : SerializationOptions
+    {
+#if (NETFX_CORE)
+        static readonly string[] SagaProperties = typeof(ISaga).GetTypeInfo().DeclaredProperties.Select(t => t.Name).ToArray();
+#else
+        private static readonly string[] SagaProperties = typeof (ISaga).GetProperties().Select(t => t.Name).ToArray();
+#endif
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SagaSerializationOptions"/>
+        /// </summary>
+        public SagaSerializationOptions() : base(SerializationOptionsFlags.None)
+        {
+        }
+
+        /// <summary>
+        /// Will always return true
+        /// </summary>
+        public override bool ShouldSerializeProperty(Type type, string propertyName)
+        {
+            if (typeof (ISaga)
+#if (NETFX_CORE)
+                .GetTypeInfo().IsAssignableFrom(type.GetTypeInfo())
+#else
+                .IsAssignableFrom(type)
+#endif
+                )
+            {
+                return SagaProperties.All(sp => sp != propertyName);
+            }
+
+            return true;
+        }
+    }
+}

--- a/Source/Bifrost/Serialization/ISerializationOptions.cs
+++ b/Source/Bifrost/Serialization/ISerializationOptions.cs
@@ -1,0 +1,41 @@
+﻿#region License
+
+//
+// Copyright (c) 2008-2015, Dolittle (http://www.dolittle.com)
+//
+// Licensed under the MIT License (http://opensource.org/licenses/MIT)
+//
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the license at 
+//
+//   http://github.com/dolittle/Bifrost/blob/master/MIT-LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#endregion
+
+using System;
+
+namespace Bifrost.Serialization
+{
+    /// <summary>
+    /// Represents the options for serialization
+    /// </summary>
+    public interface ISerializationOptions
+    {
+        /// <summary>
+        /// Gets whether a property on the given type should be serialized
+        /// </summary>
+        bool ShouldSerializeProperty(Type type, string propertyName);
+
+        /// <summary>
+        /// Gets the flag used for serialization
+        /// </summary>
+        SerializationOptionsFlags Flags { get; }
+    }
+}

--- a/Source/Bifrost/Serialization/ISerializer.cs
+++ b/Source/Bifrost/Serialization/ISerializer.cs
@@ -27,39 +27,76 @@ namespace Bifrost.Serialization
     /// </summary>
 	public interface ISerializer
 	{
-		/// <summary>
-		/// Deserialize Json to a specific type from a <see cref="string"/>
-		/// </summary>
-		/// <typeparam name="T">Type to deserialize to</typeparam>
-		/// <param name="json"><see cref="string"/> containing the Json</param>
-		/// <param name="options">Options for the serializer</param>
-		/// <returns>An deserialized</returns>
-		T FromJson<T>(string json, SerializationOptions options = null);
+        /// <summary>
+        /// Deserialize Json to a specific type from a <see cref="string"/>
+        /// </summary>
+        /// <typeparam name="T">Type to deserialize to</typeparam>
+        /// <param name="json"><see cref="string"/> containing the Json</param>
+        /// <returns>An deserialized</returns>
+        T FromJson<T>(string json);
 
-		/// <summary>
-		/// Deserialize Json to a specific type from a <see cref="string"/>
-		/// </summary>
-		/// <param name="type">Type to deserialize to</param>
-		/// <param name="json"><see cref="string"/> containing the Json</param>
-		/// <param name="options">Options for the serializer</param>
-		/// <returns>A deserialized instance</returns>
-		object FromJson(Type type, string json, SerializationOptions options = null);
+        /// <summary>
+        /// Deserialize Json to a specific type from a <see cref="string"/>
+        /// </summary>
+        /// <typeparam name="T">Type to deserialize to</typeparam>
+        /// <param name="json"><see cref="string"/> containing the Json</param>
+        /// <param name="options">Options for the serializer</param>
+        /// <returns>An deserialized</returns>
+        T FromJson<T>(string json, ISerializationOptions options);
 
-		/// <summary>
-		/// Deserialize Json into a specific instance
-		/// </summary>
-		/// <param name="instance">Instance to deserialize into</param>
-		/// <param name="json"><see cref="string"/> containing the Json</param>
-		/// <param name="options">Options for the serializer</param>
-		void FromJson(object instance, string json, SerializationOptions options = null);
+        /// <summary>
+        /// Deserialize Json to a specific type from a <see cref="string"/>
+        /// </summary>
+        /// <param name="type">Type to deserialize to</param>
+        /// <param name="json"><see cref="string"/> containing the Json</param>
+        /// <returns>A deserialized instance</returns>
+        object FromJson(Type type, string json);
 
-		/// <summary>
-		/// Serialize an object to Json as a string
-		/// </summary>
-		/// <param name="instance">Instance to serialize</param>
-		/// <param name="options">Options for the serializer</param>
-		/// <returns><see cref="string"/> containing the serialized instance</returns>
-		string ToJson(object instance, SerializationOptions options = null);
+        /// <summary>
+        /// Deserialize Json to a specific type from a <see cref="string"/>
+        /// </summary>
+        /// <param name="type">Type to deserialize to</param>
+        /// <param name="json"><see cref="string"/> containing the Json</param>
+        /// <param name="options">Options for the serializer</param>
+        /// <returns>A deserialized instance</returns>
+        object FromJson(Type type, string json, ISerializationOptions options);
+
+        /// <summary>
+        /// Deserialize Json into a specific instance
+        /// </summary>
+        /// <param name="instance">Instance to deserialize into</param>
+        /// <param name="json"><see cref="string"/> containing the Json</param>
+        void FromJson(object instance, string json);
+
+        /// <summary>
+        /// Deserialize Json into a specific instance
+        /// </summary>
+        /// <param name="instance">Instance to deserialize into</param>
+        /// <param name="json"><see cref="string"/> containing the Json</param>
+        /// <param name="options">Options for the serializer</param>
+        void FromJson(object instance, string json, ISerializationOptions options);
+
+        /// <summary>
+        /// Serialize an object to Json as a string
+        /// </summary>
+        /// <param name="instance">Instance to serialize</param>
+        /// <returns><see cref="string"/> containing the serialized instance</returns>
+        string ToJson(object instance);
+
+        /// <summary>
+        /// Serialize an object to Json as a string
+        /// </summary>
+        /// <param name="instance">Instance to serialize</param>
+        /// <param name="options">Options for the serializer</param>
+        /// <returns><see cref="string"/> containing the serialized instance</returns>
+        string ToJson(object instance, ISerializationOptions options);
+
+        /// <summary>
+        /// Serialize an object to Json as a <see cref="Stream"/>
+        /// </summary>
+        /// <param name="instance">Instance to serialize</param>
+        /// <returns><see cref="Stream"/> containing the serialized instance</returns>
+        Stream ToJsonStream(object instance);
 
         /// <summary>
         /// Serialize an object to Json as a <see cref="Stream"/>
@@ -67,7 +104,7 @@ namespace Bifrost.Serialization
         /// <param name="instance">Instance to serialize</param>
         /// <param name="options">Options for the serializer</param>
         /// <returns><see cref="Stream"/> containing the serialized instance</returns>
-        Stream ToJsonStream(object instance, SerializationOptions options = null);
+        Stream ToJsonStream(object instance, ISerializationOptions options);
 
 		/// <summary>
 		/// Deserialize Json into a key/value dictionary

--- a/Source/Bifrost/Serialization/SerializationOptionFlags.cs
+++ b/Source/Bifrost/Serialization/SerializationOptionFlags.cs
@@ -1,0 +1,47 @@
+﻿#region License
+
+//
+// Copyright (c) 2008-2015, Dolittle (http://www.dolittle.com)
+//
+// Licensed under the MIT License (http://opensource.org/licenses/MIT)
+//
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the license at 
+//
+//   http://github.com/dolittle/Bifrost/blob/master/MIT-LICENSE.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#endregion
+
+using System;
+
+namespace Bifrost.Serialization
+{
+    /// <summary>
+    /// Represents the flag options for serialization
+    /// </summary>
+    [Flags]
+    public enum SerializationOptionsFlags
+    {
+        /// <summary>
+        /// No specific options
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Use camel case for naming of properties
+        /// </summary>
+        UseCamelCase = 1,
+
+        /// <summary>
+        /// Include type names during serialization
+        /// </summary>
+        IncludeTypeNames = 2,
+    }
+}

--- a/Source/Bifrost/Serialization/SerializationOptions.cs
+++ b/Source/Bifrost/Serialization/SerializationOptions.cs
@@ -23,21 +23,51 @@ namespace Bifrost.Serialization
     /// <summary>
     /// Represents the options for serialization
     /// </summary>
-	public class SerializationOptions
-	{
-        /// <summary>
-        /// A func that gets called during serialization of properties to decide 
-        /// </summary>
-		public Func<Type, string, bool>	ShouldSerializeProperty = (t, p) => true;
+    public class SerializationOptions : ISerializationOptions
+    {
+        static readonly SerializationOptions DefaultOptions = new SerializationOptions(SerializationOptionsFlags.None);
+        static readonly SerializationOptions CamelCaseOptions = new SerializationOptions(SerializationOptionsFlags.UseCamelCase);
+        static readonly SerializationOptions IncludeTypeNamesOptions = new SerializationOptions(SerializationOptionsFlags.IncludeTypeNames);
 
         /// <summary>
-        /// Gets or sets wether or not to use camel case for naming of properties
+        /// Gets the default serialization options that will serialize all properties without any special flags.
         /// </summary>
-        public bool UseCamelCase { get; set; }
+        public static ISerializationOptions Default { get { return DefaultOptions; } }
 
         /// <summary>
-        /// Gets or sets wether or not to include type names during serialization
+        /// Gets the camel case serialization options that will serialize all properties using camel case.
         /// </summary>
-        public bool IncludeTypeNames { get; set; }
+        public static ISerializationOptions CamelCase { get { return CamelCaseOptions; } }
+
+        /// <summary>
+        /// Gets the type names serialization options that will serialize all properties including type names.
+        /// </summary>
+        public static ISerializationOptions IncludeTypeNames { get { return IncludeTypeNamesOptions; } }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SerializationOptions"/>
+        /// </summary>
+        /// <param name="flags">The serialization flags</param>
+        /// <remarks>
+        /// All instances of this class or subclasses must be immutable, because mapping from
+        /// serialization options to contract resolvers are cached for performance reasons.
+        /// </remarks>
+        protected SerializationOptions(SerializationOptionsFlags flags)
+        {
+            Flags = flags;
+        }
+
+        /// <summary>
+        /// Will always return true
+        /// </summary>
+        public virtual bool ShouldSerializeProperty(Type type, string propertyName)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the serialization flags
+        /// </summary>
+        public SerializationOptionsFlags Flags { get; private set; }
 	}
 }


### PR DESCRIPTION
(See http://www.newtonsoft.com/json/help/html/M_Newtonsoft_Json_Serialization_DefaultContractResolver__ctor_1.htm)

Fixes #676.

The easy fix was to remove `: base(true)` in SerializerContractResolver. Then I had to reintroduce caching, by making SerializationOptions immutable.