### PR TITLE
Do not expose DefaultLifecycle from IContainer. #716

### DIFF
--- a/Source/Bifrost.Autofac/Container.cs
+++ b/Source/Bifrost.Autofac/Container.cs
@@ -15,11 +15,11 @@ using IContainer = Bifrost.Execution.IContainer;
 namespace Bifrost.Autofac
 {
     /// <summary>
-    /// Represents an implementation of <see cref="IContainer"/> for AutoFac
+    /// Represents an implementation of <see cref="Execution.IContainer"/> for AutoFac
     /// </summary>
     public class Container : IContainer
     {
-        global::Autofac.IContainer _container;
+        readonly global::Autofac.IContainer _container;
 
         /// <summary>
         /// Initializes a new instance of <see cref="Container"/>
@@ -30,8 +30,9 @@ namespace Bifrost.Autofac
             _container = container;
         }
 
-
 #pragma warning disable 1591
+        public virtual BindingLifecycle DefaultLifecycle => BindingLifecycle.Transient;
+
         public T Get<T>()
         {
             return _container.Resolve<T>();
@@ -45,7 +46,10 @@ namespace Bifrost.Autofac
             }
             catch
             {
-                if (!optional) throw;
+                if (!optional)
+                {
+                    throw;
+                }
             }
 
             return default(T);
@@ -60,11 +64,7 @@ namespace Bifrost.Autofac
 
         public object Get(Type type, bool optional)
         {
-            if (optional)
-            {
-                return _container.ResolveOptional(type);
-            }
-            return _container.Resolve(type);
+            return optional ? _container.ResolveOptional(type) : _container.Resolve(type);
         }
 
         public IEnumerable<T> GetAll<T>()
@@ -84,22 +84,20 @@ namespace Bifrost.Autofac
 
         public IEnumerable<object> GetAll(Type type)
         {
-            List<object> list = ((IEnumerable) _container
-                                                   .Resolve(typeof (IEnumerable<>)
-                                                                .MakeGenericType(type)))
+            return ((IEnumerable)_container.Resolve(typeof(IEnumerable<>).MakeGenericType(type)))
                 .OfType<object>()
                 .ToList();
-
-            return list;
         }
 
         public IEnumerable<Type> GetBoundServices()
         {
-            IEnumerable<Type> types = _container.ComponentRegistry.Registrations
-                                                .SelectMany(r => r.Services.OfType<IServiceWithType>(),
-                                                            (r, s) => new {r, s})
-                                                .Select(rs => rs.r.Activator.LimitType).ToList();
-            return types;
+            return _container
+                .ComponentRegistry.Registrations
+                .SelectMany(
+                    r => r.Services.OfType<IServiceWithType>(),
+                    (r, s) => new { r, s })
+                .Select(rs => rs.r.Activator.LimitType)
+                .ToList();
         }
 
         public void Bind(Type type, Func<Type> resolveCallback)
@@ -174,8 +172,6 @@ namespace Bifrost.Autofac
             RegisterWithCallback(service, resolveCallback, DefaultLifecycle);
         }
 
-        public BindingLifecycle DefaultLifecycle { get; set; }
-
 #pragma warning restore 1591
 
         void RegisterWithCallback<T>(Type service, Func<T> resolveCallback, BindingLifecycle lifecycle)
@@ -228,15 +224,21 @@ namespace Bifrost.Autofac
                     foreach (ParameterInfo parameter in parameters)
                     {
                         object service = _container.Resolve(parameter.ParameterType);
-                        if (service == null) throw new Exception("Unkown service");
+                        if (service == null)
+                        {
+                            throw new Exception("Unkown service");
+                        }
+
                         parameterInstances.Add(service);
                     }
+
                     return Activator.CreateInstance(type, parameterInstances.ToArray());
                 }
                 catch (Exception)
                 {
                 }
             }
+
             throw new MissingDefaultConstructorException(type);
         }
     }

--- a/Source/Bifrost.Ninject/Container.cs
+++ b/Source/Bifrost.Ninject/Container.cs
@@ -21,7 +21,9 @@ namespace Bifrost.Ninject
             _boundServices = new List<Type>();
         }
 
-        public IKernel Kernel { get; private set; }
+        public virtual BindingLifecycle DefaultLifecycle => BindingLifecycle.Transient;
+
+        public IKernel Kernel { get; }
 
         public T Get<T>()
         {
@@ -91,14 +93,12 @@ namespace Bifrost.Ninject
 
         public void Bind<T>(Type type)
         {
-            Kernel.Bind<T>().To(type);
-            _boundServices.Add(typeof(T));
+            Bind<T>(type, DefaultLifecycle);
         }
 
         public void Bind(Type service, Type type)
         {
-            Kernel.Bind(service).To(type);
-            _boundServices.Add(service);
+            Bind(service, type, DefaultLifecycle);
         }
 
         public void Bind<T>(Type type, BindingLifecycle lifecycle)
@@ -128,14 +128,12 @@ namespace Bifrost.Ninject
 
         public void Bind<T>(Func<T> resolveCallback)
         {
-            Kernel.Bind<T>().ToMethod(c => resolveCallback());
-            _boundServices.Add(typeof(T));
+            Bind(resolveCallback, DefaultLifecycle);
         }
 
         public void Bind(Type service, Func<Type, object> resolveCallback)
         {
-            Kernel.Bind(service).ToMethod(c => resolveCallback(c.Request.Service));
-            _boundServices.Add(service);
+            Bind(service, resolveCallback, DefaultLifecycle);
         }
 
         public void Bind<T>(Func<T> resolveCallback, BindingLifecycle lifecycle)
@@ -149,7 +147,5 @@ namespace Bifrost.Ninject
             Kernel.Bind(service).ToMethod(c => resolveCallback(c.Request.Service)).WithLifecycle(lifecycle);
             _boundServices.Add(service);
         }
-
-        public BindingLifecycle DefaultLifecycle { get; set; }
     }
 }

--- a/Source/Bifrost.SimpleInjector/Container.cs
+++ b/Source/Bifrost.SimpleInjector/Container.cs
@@ -3,18 +3,9 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bifrost.Execution;
-using SimpleInjector;
-using SimpleInjector.Extensions;
-using SimpleInjector.Extensions.Decorators;
-using SimpleInjector.Advanced;
-using SimpleInjector.Advanced.Internal;
-using SimpleInjector.Diagnostics;
-using SimpleInjector.Integration.Web;
-using IContainer = Bifrost.Execution.IContainer;
-using System;
-using System.Collections.Generic;
 
 namespace Bifrost.SimpleInjector
 {
@@ -26,7 +17,8 @@ namespace Bifrost.SimpleInjector
         {
             _container = container;
         }
-        public BindingLifecycle DefaultLifecycle { get; set; }
+
+        public virtual BindingLifecycle DefaultLifecycle => BindingLifecycle.Transient;
 
         public T Get<T>()
         {
@@ -41,7 +33,10 @@ namespace Bifrost.SimpleInjector
             }
             catch
             {
-                if (!optional) throw;
+                if (!optional)
+                {
+                    throw;
+                }
             }
 
             return default(T);
@@ -52,7 +47,7 @@ namespace Bifrost.SimpleInjector
             return _container.GetInstance(type);
         }
 
-        public object Get(Type type, bool optional = false)
+        public object Get(Type type, bool optional)
         {
             try
             {
@@ -60,7 +55,10 @@ namespace Bifrost.SimpleInjector
             }
             catch
             {
-                if (!optional) throw;
+                if (!optional)
+                {
+                    throw;
+                }
             }
 
             return null;
@@ -95,12 +93,12 @@ namespace Bifrost.SimpleInjector
 
         public void Bind(Type service, Func<Type> resolveCallback)
         {
-            _container.Register(service, resolveCallback);
+            _container.Register(service, resolveCallback, DefaultLifecycle);
         }
 
         public void Bind<T>(Func<Type> resolveCallback)
         {
-            _container.Register(typeof(T), resolveCallback);
+            _container.Register(typeof(T), resolveCallback, DefaultLifecycle);
         }
 
         public void Bind(Type service, Func<Type> resolveCallback, BindingLifecycle lifecycle)
@@ -121,27 +119,27 @@ namespace Bifrost.SimpleInjector
 
         public void Bind(Type service, Func<Type, object> resolveCallback)
         {
-            _container.Register(service, () => resolveCallback(service));
+            _container.Register(service, resolveCallback, DefaultLifecycle);
         }
 
         public void Bind<T>(Func<T> resolveCallback, BindingLifecycle lifecycle)
         {
-            _container.Register<T>(resolveCallback, lifecycle);
+            _container.Register(resolveCallback, lifecycle);
         }
 
         public void Bind(Type service, Func<Type, object> resolveCallback, BindingLifecycle lifecycle)
         {
-            throw new NotImplementedException();
+            _container.Register(service, resolveCallback, lifecycle);
         }
 
         public void Bind<T>(Type type)
         {
-            _container.Register(typeof(T), () => type);
+            _container.Register(typeof(T), () => type, DefaultLifecycle);
         }
 
         public void Bind(Type service, Type type)
         {
-            _container.Register(service, () => type);
+            _container.Register(service, () => type, DefaultLifecycle);
         }
 
         public void Bind<T>(Type type, BindingLifecycle lifecycle)

--- a/Source/Bifrost.SimpleInjector/ContainerExtensions.cs
+++ b/Source/Bifrost.SimpleInjector/ContainerExtensions.cs
@@ -17,14 +17,22 @@ namespace Bifrost.SimpleInjector
             Func<Type> typeResolver = () => { return resolveCallback.Invoke().GetType(); };
             container.Register(typeof(T), typeResolver, lifecycle);
         }
+
         public static void Register<T>(this global::SimpleInjector.Container container, Func<Type> resolveCallback, BindingLifecycle lifecycle)
         {
             container.Register(typeof(T), resolveCallback, lifecycle);
         }
+
         public static void Register(this global::SimpleInjector.Container container, Type service, Func<Type> resolveCallback, BindingLifecycle lifecycle)
         {
             var lifestyle = ResolveLifestyle(lifecycle);
             container.Register(service, resolveCallback, lifestyle);
+        }
+
+        public static void Register(this global::SimpleInjector.Container container, Type service, Func<Type, object> resolveCallback, BindingLifecycle lifecycle)
+        {
+            var lifestyle = ResolveLifestyle(lifecycle);
+            container.Register(service, () => resolveCallback, lifestyle);
         }
 
         private static Lifestyle ResolveLifestyle(BindingLifecycle lifecycle)

--- a/Source/Bifrost.StructureMap/Container.cs
+++ b/Source/Bifrost.StructureMap/Container.cs
@@ -3,156 +3,161 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Bifrost.Execution;
-using System.Collections.Generic;
-using InstanceScope = global::StructureMap.InstanceScope;
+using StructureMap;
+using IContainer = Bifrost.Execution.IContainer;
 
 namespace Bifrost.StructureMap
 {
-	public class Container : IContainer
-	{
-		global::StructureMap.IContainer _container;
+    public class Container : IContainer
+    {
+        readonly global::StructureMap.IContainer _container;
 
-		public Container (global::StructureMap.IContainer container)
-		{
-			_container = container;
-		}
+        public Container(global::StructureMap.IContainer container)
+        {
+            _container = container;
+        }
 
-		public T Get<T> ()
-		{
-			return _container.GetInstance<T>();
-		}
+        public virtual BindingLifecycle DefaultLifecycle => BindingLifecycle.Transient;
 
-		public T Get<T> (bool optional)
-		{
-			try 
-			{
-				return _container.GetInstance<T>();
-			} 
-			catch 
-			{
-				if( !optional ) throw;
-			}
+        public T Get<T>()
+        {
+            return _container.GetInstance<T>();
+        }
 
-			return default(T);
-		}
+        public T Get<T>(bool optional)
+        {
+            try
+            {
+                return _container.GetInstance<T>();
+            }
+            catch
+            {
+                if (!optional)
+                {
+                    throw;
+                }
+            }
 
-		public object Get (Type type)
-		{
-			return _container.GetInstance(type);
-		}
+            return default(T);
+        }
 
-		public object Get (Type type, bool optional = false)
-		{
-			try 
-			{
-				return _container.GetInstance (type);
-			}
-			catch
-			{
-				if( !optional ) throw;
-			}
+        public object Get(Type type)
+        {
+            return _container.GetInstance(type);
+        }
 
-			return null;
-		}
+        public object Get(Type type, bool optional)
+        {
+            try
+            {
+                return _container.GetInstance(type);
+            }
+            catch
+            {
+                if (!optional)
+                {
+                    throw;
+                }
+            }
 
-		public IEnumerable<T> GetAll<T> ()
-		{
-			return _container.GetAllInstances<T>();
-		}
+            return null;
+        }
 
-		public bool HasBindingFor (Type type)
-		{
-			return _container.Model.HasImplementationsFor(type);
-		}
+        public IEnumerable<T> GetAll<T>()
+        {
+            return _container.GetAllInstances<T>();
+        }
 
-		public bool HasBindingFor<T> ()
-		{
-			return _container.Model.HasImplementationsFor<T>();
-		}
+        public bool HasBindingFor(Type type)
+        {
+            return _container.Model.HasImplementationsFor(type);
+        }
 
-		public IEnumerable<object> GetAll (Type type)
-		{
-			var list = new List<object>();
-			foreach( var instance in _container.GetAllInstances(type) ) list.Add (instance);
-			return list;
-		}
+        public bool HasBindingFor<T>()
+        {
+            return _container.Model.HasImplementationsFor<T>();
+        }
 
-		public IEnumerable<Type> GetBoundServices ()
-		{
-			return _container.Model.PluginTypes.Select(p=>p.PluginType);
-		}
+        public IEnumerable<object> GetAll(Type type)
+        {
+            return _container.GetAllInstances(type).Cast<object>().ToList();
+        }
 
-		public void Bind (Type service, Func<Type> resolveCallback)
-		{
-			throw new NotImplementedException();
-		}
+        public IEnumerable<Type> GetBoundServices()
+        {
+            return _container.Model.PluginTypes.Select(p => p.PluginType);
+        }
 
-		public void Bind<T> (Func<Type> resolveCallback)
-		{
-			throw new NotImplementedException ();
-		}
+        public void Bind(Type service, Func<Type> resolveCallback)
+        {
+            throw new NotImplementedException();
+        }
 
-		public void Bind (Type service, Func<Type> resolveCallback, BindingLifecycle lifecycle)
-		{
-			throw new NotImplementedException ();
-		}
+        public void Bind<T>(Func<Type> resolveCallback)
+        {
+            throw new NotImplementedException();
+        }
 
-		public void Bind<T> (Func<Type> resolveCallback, BindingLifecycle lifecycle)
-		{
-			throw new NotImplementedException ();
-		}
+        public void Bind(Type service, Func<Type> resolveCallback, BindingLifecycle lifecycle)
+        {
+            throw new NotImplementedException();
+        }
 
-		public void Bind<T> (Type type)
-		{
-			_container.Configure (c=>c.ForRequestedType<T>().TheDefault.Is.Type (type));
-		}
+        public void Bind<T>(Func<Type> resolveCallback, BindingLifecycle lifecycle)
+        {
+            throw new NotImplementedException();
+        }
 
-		public void Bind (Type service, Type type)
-		{
-			_container.Configure (c=>c.ForRequestedType(service).TheDefaultIsConcreteType(type));
-		}
+        public void Bind<T>(Type type)
+        {
+            _container.Configure(c => c.ForRequestedType<T>().TheDefault.Is.Type(type));
+        }
 
-		public void Bind<T> (Type type, BindingLifecycle lifecycle)
-		{
+        public void Bind(Type service, Type type)
+        {
+            _container.Configure(c => c.ForRequestedType(service).TheDefaultIsConcreteType(type));
+        }
 
-			_container.Configure (c=>c.ForRequestedType<T>().CacheBy(GetInstanceScopeFor(lifecycle)).TheDefault.Is.Type (type));
-		}
+        public void Bind<T>(Type type, BindingLifecycle lifecycle)
+        {
+            _container.Configure(c => c.ForRequestedType<T>().CacheBy(GetInstanceScopeFor(lifecycle)).TheDefault.Is.Type(type));
+        }
 
-		public void Bind (Type service, Type type, BindingLifecycle lifecycle)
-		{
-			_container.Configure (c=>c.ForRequestedType(service).CacheBy(GetInstanceScopeFor(lifecycle)).TheDefaultIsConcreteType(type));
-		}
+        public void Bind(Type service, Type type, BindingLifecycle lifecycle)
+        {
+            _container.Configure(c => c.ForRequestedType(service).CacheBy(GetInstanceScopeFor(lifecycle)).TheDefaultIsConcreteType(type));
+        }
 
-		public void Bind<T> (T instance)
-		{
-			_container.Configure (c => c.ForRequestedType<T>().Add(instance));
-		}
+        public void Bind<T>(T instance)
+        {
+            _container.Configure(c => c.ForRequestedType<T>().Add(instance));
+        }
 
-		public void Bind (Type service, object instance)
-		{
-			_container.Configure (c => c.ForRequestedType(service).Add (instance));
-		}
+        public void Bind(Type service, object instance)
+        {
+            _container.Configure(c => c.ForRequestedType(service).Add(instance));
+        }
 
 
-		InstanceScope GetInstanceScopeFor(BindingLifecycle lifecycle)
-		{
-			switch( lifecycle ) 
-			{
-			case BindingLifecycle.Transient:
-			{
-				return InstanceScope.Transient;
-			};
-
-			case BindingLifecycle.Request: return InstanceScope.PerRequest;
-			case BindingLifecycle.Singleton: return InstanceScope.Singleton;
-			case BindingLifecycle.Thread: return InstanceScope.ThreadLocal;
-			}
-
-			return InstanceScope.Transient;
-		}
-
+        InstanceScope GetInstanceScopeFor(BindingLifecycle lifecycle)
+        {
+            switch (lifecycle)
+            {
+                case BindingLifecycle.Transient:
+                    return InstanceScope.Transient;
+                case BindingLifecycle.Request:
+                    return InstanceScope.PerRequest;
+                case BindingLifecycle.Singleton:
+                    return InstanceScope.Singleton;
+                case BindingLifecycle.Thread:
+                    return InstanceScope.ThreadLocal;
+                default:
+                    return InstanceScope.Transient;
+            }
+        }
 
         public void Bind<T>(Func<T> resolveCallback)
         {
@@ -173,8 +178,5 @@ namespace Bifrost.StructureMap
         {
             throw new NotImplementedException();
         }
-
-        public BindingLifecycle DefaultLifecycle { get; set; }
     }
 }
-

--- a/Source/Bifrost/Configuration/Configure.cs
+++ b/Source/Bifrost/Configuration/Configure.cs
@@ -28,14 +28,14 @@ namespace Bifrost.Configuration
         /// </summary>
         public static Configure Instance { get; private set; }
 
-
-        Configure(IContainer container, BindingLifecycle defaultLifecycle,  IDefaultConventions defaultConventions, IDefaultBindings defaultBindings, AssembliesConfiguration assembliesConfiguration)
+        Configure(
+            IContainer container,
+            IDefaultConventions defaultConventions,
+            IDefaultBindings defaultBindings,
+            AssembliesConfiguration assembliesConfiguration)
         {
             SystemName = "[Not Set]";
-
             AssembliesConfiguration = assembliesConfiguration;
-
-            container.DefaultLifecycle = defaultLifecycle;
             container.Bind<IConfigure>(this);
 
             Container = container;
@@ -88,37 +88,36 @@ namespace Bifrost.Configuration
             ThrowIfCanCreateContainerDoesNotHaveDefaultConstructor(canCreateContainerType);
             var canCreateContainerInstance = Activator.CreateInstance(canCreateContainerType) as ICanCreateContainer;
             var container = canCreateContainerInstance.CreateContainer();
-            var configure = With(container, BindingLifecycle.Transient, assembliesConfiguration, assemblyProvider, contractToImplementorsMap);
+            var configure = With(
+                container,
+                assembliesConfiguration,
+                assemblyProvider,
+                contractToImplementorsMap);
             configure.EntryAssembly = canCreateContainerType.GetTypeInfo().Assembly;
             configure.Initialize();
             return configure;
         }
 
         /// <summary>
-        /// Configure with a specific <see cref="IContainer"/> and the <see cref="BindingLifecycle">Lifecycle</see> of objects set to none
+        /// Configure with a specific <see cref="IContainer"/>.
         /// </summary>
-        /// <param name="container"><see cref="IContainer"/> to configure with</param>
-        /// <param name="assembliesConfiguration"><see cref="AssembliesConfiguration"/> to use</param>
-        /// <param name="assemblyProvider"><see cref="IAssemblyProvider"/> to use for providing assemblies</param>
-        /// <param name="contractToImplementorsMap"><see cref="IContractToImplementorsMap"/> for keeping track of the relationship between contracts and implementors</param>
-        /// <returns>Configuration object to continue configuration on</returns>
-        public static Configure With(IContainer container, AssembliesConfiguration assembliesConfiguration, IAssemblyProvider assemblyProvider, IContractToImplementorsMap contractToImplementorsMap)
+        /// <param name="container"><see cref="IContainer"/> to configure with.</param>
+        /// <param name="assembliesConfiguration"><see cref="IAssembliesConfiguration"/> to use.</param>
+        /// <param name="assemblyProvider"><see cref="IAssemblyProvider"/> to use for providing assemblies.</param>
+        /// <param name="contractToImplementorsMap"><see cref="IContractToImplementorsMap"/> for keeping track of
+        /// the relationship between contracts and implementors.</param>
+        /// <returns>Configuration object to continue configuration on.</returns>
+        public static Configure With(
+            IContainer container,
+            AssembliesConfiguration assembliesConfiguration,
+            IAssemblyProvider assemblyProvider,
+            IContractToImplementorsMap contractToImplementorsMap)
         {
-            return With(container, BindingLifecycle.Transient, assembliesConfiguration, assemblyProvider, contractToImplementorsMap);
-        }
-
-        /// <summary>
-        /// Configure with a specific <see cref="IContainer"/>
-        /// </summary>
-        /// <param name="container"><see cref="IContainer"/> to configure with</param>
-        /// <param name="defaultObjectLifecycle">Default <see cref="BindingLifecycle"/> for object creation/management</param>
-        /// <param name="assembliesConfiguration"><see cref="AssembliesConfiguration"/> to use</param>
-        /// <param name="assemblyProvider"><see cref="IAssemblyProvider"/> to use for providing assemblies</param>
-        /// <param name="contractToImplementorsMap"><see cref="IContractToImplementorsMap"/> for keeping track of the relationship between contracts and implementors</param>
-        /// <returns>Configuration object to continue configuration on</returns>
-        public static Configure With(IContainer container, BindingLifecycle defaultObjectLifecycle, AssembliesConfiguration assembliesConfiguration, IAssemblyProvider assemblyProvider, IContractToImplementorsMap contractToImplementorsMap)
-        {
-            return With(container, defaultObjectLifecycle, new DefaultConventions(container), new DefaultBindings(assembliesConfiguration, assemblyProvider, contractToImplementorsMap), assembliesConfiguration);
+            return With(
+                container,
+                new DefaultConventions(container),
+                new DefaultBindings(assembliesConfiguration, assemblyProvider, contractToImplementorsMap),
+                assembliesConfiguration);
         }
 
         /// <summary>
@@ -129,7 +128,6 @@ namespace Bifrost.Configuration
             lock (InstanceLock) Instance = null;
         }
 
-
         /// <summary>
         /// Configure with a specific <see cref="IContainer"/>, <see cref="IDefaultConventions"/> and <see cref="IDefaultBindings"/>
         /// </summary>
@@ -138,28 +136,17 @@ namespace Bifrost.Configuration
         /// <param name="defaultBindings"><see cref="IDefaultBindings"/> to use</param>
         /// <param name="assembliesConfiguration"><see cref="AssembliesConfiguration"/> to use</param>
         /// <returns></returns>
-        public static Configure With(IContainer container, IDefaultConventions defaultConventions, IDefaultBindings defaultBindings, AssembliesConfiguration assembliesConfiguration)
-        {
-            return With(container, BindingLifecycle.Transient, defaultConventions, defaultBindings, assembliesConfiguration);
-        }
-
-
-        /// <summary>
-        /// Configure with a specific <see cref="IContainer"/>, <see cref="IDefaultConventions"/> and <see cref="IDefaultBindings"/>
-        /// </summary>
-        /// <param name="container"><see cref="IContainer"/> to configure with</param>
-        /// <param name="defaultObjectLifecycle">Default <see cref="BindingLifecycle"/> for object creation/management</param>
-        /// <param name="defaultConventions"><see cref="IDefaultConventions"/> to use</param>
-        /// <param name="defaultBindings"><see cref="IDefaultBindings"/> to use</param>
-        /// <param name="assembliesConfiguration"><see cref="AssembliesConfiguration"/> to use</param>
-        /// <returns></returns>
-        public static Configure With(IContainer container, BindingLifecycle defaultObjectLifecycle, IDefaultConventions defaultConventions, IDefaultBindings defaultBindings, AssembliesConfiguration assembliesConfiguration)
+        public static Configure With(
+            IContainer container,
+            IDefaultConventions defaultConventions,
+            IDefaultBindings defaultBindings,
+            AssembliesConfiguration assembliesConfiguration)
         {
             if (Instance == null)
             {
                 lock (InstanceLock)
                 {
-                    Instance = new Configure(container, defaultObjectLifecycle, defaultConventions, defaultBindings, assembliesConfiguration);
+                    Instance = new Configure(container, defaultConventions, defaultBindings, assembliesConfiguration);
                 }
             }
 
@@ -187,12 +174,6 @@ namespace Bifrost.Configuration
         public IQualityAssurance QualityAssurance { get; private set; }
 		public CultureInfo Culture { get; set; }
 		public CultureInfo UICulture { get; set; }
-
-        public BindingLifecycle DefaultLifecycle 
-        {
-            get { return Container.DefaultLifecycle; }
-            set { Container.DefaultLifecycle = value; }
-        }
 
         public void Initialize()
         {

--- a/Source/Bifrost/Configuration/ExecutionContextConfiguration.cs
+++ b/Source/Bifrost/Configuration/ExecutionContextConfiguration.cs
@@ -14,7 +14,7 @@ namespace Bifrost.Configuration
 #pragma warning disable 1591 // Xml Comments
         public void Initialize(IContainer container)
         {
-            container.Bind<IExecutionContext>(() => container.Get<IExecutionContextManager>().Current, container.DefaultLifecycle);
+            container.Bind(() => container.Get<IExecutionContextManager>().Current);
         }
 #pragma warning restore 1591 // Xml Comments
     }

--- a/Source/Bifrost/Configuration/IConfigure.cs
+++ b/Source/Bifrost/Configuration/IConfigure.cs
@@ -9,15 +9,15 @@ using Bifrost.Execution;
 
 namespace Bifrost.Configuration
 {
-	/// <summary>
-	/// Defines the configuration for Bifrost
-	/// </summary>
-	public interface IConfigure 
-	{
-		/// <summary>
-		/// Gets the container that is used
-		/// </summary>
-		IContainer Container { get; }
+    /// <summary>
+    /// Defines the configuration for Bifrost
+    /// </summary>
+    public interface IConfigure
+    {
+        /// <summary>
+        /// Gets the container that is used
+        /// </summary>
+        IContainer Container { get; }
 
         /// <summary>
         /// Gets or sets the name of the currently running system
@@ -29,16 +29,16 @@ namespace Bifrost.Configuration
         /// </summary>
         Assembly EntryAssembly { get; }
 
-		/// <summary>
-		/// Gets the configuration for commands
-		/// </summary>
-		ICommandsConfiguration Commands { get; }
+        /// <summary>
+        /// Gets the configuration for commands
+        /// </summary>
+        ICommandsConfiguration Commands { get; }
 
-		/// <summary>
-		/// Gets the configuration for events.
+        /// <summary>
+        /// Gets the configuration for events.
         /// Supports specific storage
-		/// </summary>
-		IEventsConfiguration Events { get; }
+        /// </summary>
+        IEventsConfiguration Events { get; }
 
         /// <summary>
         /// Gets the configuration for <see cref="Bifrost.Tasks.Task">Tasks</see>
@@ -46,21 +46,21 @@ namespace Bifrost.Configuration
         /// </summary>
         ITasksConfiguration Tasks { get; }
 
-		/// <summary>
-		/// Gets the configuration for views
-		/// </summary>
-		IViewsConfiguration Views { get; }
+        /// <summary>
+        /// Gets the configuration for views
+        /// </summary>
+        IViewsConfiguration Views { get; }
 
-		/// <summary>
-		/// Gets the convention manager for bindings
-		/// </summary>
-		IBindingConventionManager ConventionManager { get; }
+        /// <summary>
+        /// Gets the convention manager for bindings
+        /// </summary>
+        IBindingConventionManager ConventionManager { get; }
 
-		/// <summary>
-		/// Gets the configuration for sagas
+        /// <summary>
+        /// Gets the configuration for sagas
         /// Supports specific storage
-		/// </summary>
-		ISagasConfiguration Sagas { get; }
+        /// </summary>
+        ISagasConfiguration Sagas { get; }
 
         /// <summary>
         /// Gets the configureation for serialization
@@ -96,25 +96,20 @@ namespace Bifrost.Configuration
         /// Gets the configuration for assemblies and how they are treated
         /// </summary>
         AssembliesConfiguration Assemblies { get; }
-		
-		/// <summary>
-		/// Gets or sets the <see cref="CultureInfo">culture</see> to use in Bifrost
-		/// </summary>
-		CultureInfo Culture { get; set; }
-
-		/// <summary>
-		/// Gets or sets the <see cref="CultureInfo">UI culture</see> to use in Bifrost
-		/// </summary>
-		CultureInfo UICulture { get; set; }
 
         /// <summary>
-        /// Gets or sets the default <see cref="BindingLifeCycle"/> for objects when created/managed by the <see cref="IContainer"/>
+        /// Gets or sets the <see cref="CultureInfo">culture</see> to use in Bifrost
         /// </summary>
-        BindingLifecycle DefaultLifecycle { get; set; }
+        CultureInfo Culture { get; set; }
 
-		/// <summary>
-		/// Initializes Bifrost after configuration
-		/// </summary>
-		void Initialize();
-	}
+        /// <summary>
+        /// Gets or sets the <see cref="CultureInfo">UI culture</see> to use in Bifrost
+        /// </summary>
+        CultureInfo UICulture { get; set; }
+
+        /// <summary>
+        /// Initializes Bifrost after configuration
+        /// </summary>
+        void Initialize();
+    }
 }

--- a/Source/Bifrost/Execution/IContainer.cs
+++ b/Source/Bifrost/Execution/IContainer.cs
@@ -13,13 +13,6 @@ namespace Bifrost.Execution
     public interface IContainer
     {
         /// <summary>
-        /// Gets or sets the <see cref="BindingLifecycle"/> for objects.
-        /// This property usually guides the implementing container for default bindings it may create for types that 
-        /// does not have an explicit binding and is not abstract or an interface
-        /// </summary>
-        BindingLifecycle DefaultLifecycle { get; set; }
-
-        /// <summary>
         /// Get an instance of a specific type
         /// </summary>
         /// <typeparam name="T">Type to get instance of</typeparam>
@@ -47,7 +40,7 @@ namespace Bifrost.Execution
         /// <param name="type">Type to get instance of</param>
         /// <param name="optional">If the binding is optional, return null and not throw an exception</param>
         /// <returns>Instance of the type</returns>
-        object Get(Type type, bool optional = false);
+        object Get(Type type, bool optional);
 
         /// <summary>
         /// Get all instances of a specific type


### PR DESCRIPTION
Instead clients should set the default lifecycle on the container either
before returning from ICanCreateContainer.CreateContainer or before the call to Configure.With.

Original issue: ProCoSys/Bifrost#16

Original commit: https://github.com/ProCoSys/Bifrost/commit/7393a03d3c437675eff96d1b9677ece6ed0cc9f6