### PR TITLE
Don't include command security proxies in Bifrost/Application. #759

### DIFF
--- a/Source/Bifrost.Specs/Utils/for_StringMapper/when_resolving_a_string_without_any_match.cs
+++ b/Source/Bifrost.Specs/Utils/for_StringMapper/when_resolving_a_string_without_any_match.cs
@@ -25,6 +25,6 @@ namespace Bifrost.Specs.Utils.for_StringMapper
 
         Because of = () => result = mapper.Resolve(input);
 
-        It should_return_empty = () => result.ShouldEqual(string.Empty);
+        It should_return_null = () => result.ShouldBeNull();
     }
 }

--- a/Source/Bifrost.Web/Applications/ApplicationRouteHandler.cs
+++ b/Source/Bifrost.Web/Applications/ApplicationRouteHandler.cs
@@ -10,8 +10,8 @@ namespace Bifrost.Web.Applications
 {
     public class ApplicationRouteHandler : IRouteHandler
     {
-        string _url;
-        Assembly _assembly;
+        readonly string _url;
+        readonly Assembly _assembly;
         IHttpHandler _httpHandler;
 
         public ApplicationRouteHandler(string url, Assembly assembly)
@@ -22,10 +22,7 @@ namespace Bifrost.Web.Applications
 
         public IHttpHandler GetHttpHandler(RequestContext requestContext)
         {
-            if (_httpHandler == null)
-                _httpHandler = new ApplicationRouteHttpHandler(_url, _assembly);
-
-            return _httpHandler;
+            return _httpHandler ?? (_httpHandler = new ApplicationRouteHttpHandler(_url, _assembly));
         }
     }
 }

--- a/Source/Bifrost.Web/Assets/AssetManagerRoute.cs
+++ b/Source/Bifrost.Web/Assets/AssetManagerRoute.cs
@@ -2,15 +2,14 @@
  *  Copyright (c) 2008-2017 Dolittle. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-using System.Reflection;
 using System.Web.Routing;
 
 namespace Bifrost.Web.Assets
 {
     public class AssetManagerRoute : Route
     {
-        public AssetManagerRoute(string url) 
-            : base(url, new AssetManagerRouteHandler(url))
+        public AssetManagerRoute(string url)
+            : base(url, new AssetManagerRouteHandler())
         {
         }
 

--- a/Source/Bifrost.Web/Assets/AssetManagerRouteHandler.cs
+++ b/Source/Bifrost.Web/Assets/AssetManagerRouteHandler.cs
@@ -2,7 +2,6 @@
  *  Copyright (c) 2008-2017 Dolittle. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-using System.Reflection;
 using System.Web;
 using System.Web.Routing;
 
@@ -10,20 +9,11 @@ namespace Bifrost.Web.Assets
 {
     public class AssetManagerRouteHandler : IRouteHandler
     {
-        string _url;
         IHttpHandler _httpHandler;
-
-        public AssetManagerRouteHandler(string url)
-        {
-            _url = url;
-        }
 
         public IHttpHandler GetHttpHandler(RequestContext requestContext)
         {
-            if (_httpHandler == null)
-                _httpHandler = new AssetManagerRouteHttpHandler(_url);
-
-            return _httpHandler;
+            return _httpHandler ?? (_httpHandler = new AssetManagerRouteHttpHandler());
         }
     }
 }

--- a/Source/Bifrost.Web/Assets/AssetManagerRouteHttpHandler.cs
+++ b/Source/Bifrost.Web/Assets/AssetManagerRouteHttpHandler.cs
@@ -2,38 +2,30 @@
  *  Copyright (c) 2008-2017 Dolittle. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-using System.Linq;
-using System.Reflection;
 using System.Web;
 using System.Collections.Generic;
-using System.IO;
-using Newtonsoft.Json;
-using System.Text;
+using System.Web;
 using Bifrost.Configuration;
+using Newtonsoft.Json;
 
 namespace Bifrost.Web.Assets
 {
     public class AssetManagerRouteHttpHandler : IHttpHandler
     {
-        string _url;
-
-        public AssetManagerRouteHttpHandler(string url)
-        {
-            _url = url;
-        }
-
-        public bool IsReusable { get { return true; } }
+        public bool IsReusable => true;
 
         public void ProcessRequest(HttpContext context)
         {
             var assetsManager = Configure.Instance.Container.Get<IAssetsManager>();
             IEnumerable<string> assets = new string[0];
             var extension = context.Request.Params["extension"];
-            if( extension != null ) 
+            if (extension != null)
             {
                 assets = assetsManager.GetFilesForExtension(extension);
                 if (context.Request.Params["structure"] != null)
+                {
                     assets = assetsManager.GetStructureForExtension(extension);
+                }
             }
             var serialized = JsonConvert.SerializeObject(assets);
             context.Response.Write(serialized);

--- a/Source/Bifrost.Web/Configuration/ConfigurationRouteHandler.cs
+++ b/Source/Bifrost.Web/Configuration/ConfigurationRouteHandler.cs
@@ -2,8 +2,8 @@
  *  Copyright (c) 2008-2017 Dolittle. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-using System.Web.Routing;
 using System.Web;
+using System.Web.Routing;
 
 namespace Bifrost.Web.Configuration
 {
@@ -13,10 +13,7 @@ namespace Bifrost.Web.Configuration
 
         public IHttpHandler GetHttpHandler(RequestContext requestContext)
         {
-            if (_httpHandler == null)
-                _httpHandler = new ConfigurationRouteHttpHandler();
-
-            return _httpHandler;
+            return _httpHandler ?? (_httpHandler = new ConfigurationRouteHttpHandler());
         }
     }
 }

--- a/Source/Bifrost.Web/Proxies/GeneratedProxies.cs
+++ b/Source/Bifrost.Web/Proxies/GeneratedProxies.cs
@@ -16,9 +16,10 @@ namespace Bifrost.Web.Proxies
     [Singleton]
     public class GeneratedProxies
     {
+        public string All { get; }
+
         public GeneratedProxies(
             CommandProxies commandProxies,
-            CommandSecurityProxies commandSecurityProxies,
             QueryProxies queryProxies,
             ReadModelProxies readModelProxies,
             ServiceProxies serviceProxies,
@@ -29,7 +30,6 @@ namespace Bifrost.Web.Proxies
         {
             var builder = new StringBuilder();
             builder.Append(commandProxies.Generate());
-            builder.Append(commandSecurityProxies.Generate());
             builder.Append(readModelProxies.Generate());
             builder.Append(queryProxies.Generate());
             builder.Append(serviceProxies.Generate());
@@ -45,7 +45,5 @@ namespace Bifrost.Web.Proxies
 
             All = builder.ToString();
         }
-
-        public string All { get; private set; }
     }
 }

--- a/Source/Bifrost.Web/Proxies/ProxyRouteHandler.cs
+++ b/Source/Bifrost.Web/Proxies/ProxyRouteHandler.cs
@@ -2,8 +2,8 @@
  *  Copyright (c) 2008-2017 Dolittle. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-using System.Web.Routing;
 using System.Web;
+using System.Web.Routing;
 
 namespace Bifrost.Web.Proxies
 {
@@ -13,10 +13,7 @@ namespace Bifrost.Web.Proxies
 
         public IHttpHandler GetHttpHandler(RequestContext requestContext)
         {
-            if (_httpHandler == null)
-                _httpHandler = new ProxyRouteHttpHandler();
-
-            return _httpHandler;
+            return _httpHandler ?? (_httpHandler = new ProxyRouteHttpHandler());
         }
     }
 }

--- a/Source/Bifrost.Web/Proxies/ProxyRouteHttpHandler.cs
+++ b/Source/Bifrost.Web/Proxies/ProxyRouteHttpHandler.cs
@@ -11,15 +11,15 @@ namespace Bifrost.Web.Proxies
     {
         GeneratedProxies _proxies;
 
-        public ProxyRouteHttpHandler()
-        {
-        }
-
-        public bool IsReusable { get { return true; } }
+        public bool IsReusable => true;
 
         public void ProcessRequest(HttpContext context)
         {
-            if (_proxies == null) _proxies = Configure.Instance.Container.Get<GeneratedProxies>();
+            if (_proxies == null)
+            {
+                _proxies = Configure.Instance.Container.Get<GeneratedProxies>();
+            }
+
             context.Response.ContentType = "text/javascript";
             context.Response.Write(_proxies.All);
         }

--- a/Source/Bifrost.Web/Security/SecurityRouteHandler.cs
+++ b/Source/Bifrost.Web/Security/SecurityRouteHandler.cs
@@ -2,8 +2,8 @@
  *  Copyright (c) 2008-2017 Dolittle. All rights reserved.
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-using System.Web.Routing;
 using System.Web;
+using System.Web.Routing;
 
 namespace Bifrost.Web.Security
 {
@@ -13,10 +13,7 @@ namespace Bifrost.Web.Security
 
         public IHttpHandler GetHttpHandler(RequestContext requestContext)
         {
-            if (_httpHandler == null)
-                _httpHandler = new SecurityRouteHttpHandler();
-
-            return _httpHandler;
+            return _httpHandler ?? (_httpHandler = new SecurityRouteHttpHandler());
         }
     }
 }

--- a/Source/Bifrost.Web/Security/SecurityRouteHttpHandler.cs
+++ b/Source/Bifrost.Web/Security/SecurityRouteHttpHandler.cs
@@ -10,11 +10,7 @@ namespace Bifrost.Web.Security
 {
     public class SecurityRouteHttpHandler : IHttpHandler
     {
-        public SecurityRouteHttpHandler()
-        {
-        }
-
-        public bool IsReusable { get { return true; } }
+        public bool IsReusable => true;
 
         public void ProcessRequest(HttpContext context)
         {

--- a/Source/Bifrost.Web/Services/RestServiceRouteHandler.cs
+++ b/Source/Bifrost.Web/Services/RestServiceRouteHandler.cs
@@ -10,8 +10,8 @@ namespace Bifrost.Web.Services
 {
     public class RestServiceRouteHandler : IRouteHandler
     {
-        Type _type;
-        string _url;
+        readonly Type _type;
+        readonly string _url;
         IHttpHandler _httpHandler;
 
         public RestServiceRouteHandler(Type type, string url)
@@ -22,10 +22,7 @@ namespace Bifrost.Web.Services
 
         public IHttpHandler GetHttpHandler(RequestContext requestContext)
         {
-            if (_httpHandler == null)
-                _httpHandler = new RestServiceRouteHttpHandler(_type, _url);
-
-            return _httpHandler;
+            return _httpHandler ?? (_httpHandler = new RestServiceRouteHttpHandler(_type, _url));
         }
     }
 }

--- a/Source/Bifrost/Utils/StringMapper.cs
+++ b/Source/Bifrost/Utils/StringMapper.cs
@@ -15,24 +15,16 @@ namespace Bifrost.Utils
         List<IStringMapping> _mappings = new List<IStringMapping>();
 
 #pragma warning disable 1591 // Xml Comments
-        public IEnumerable<IStringMapping> Mappings { get { return _mappings; } }
+        public IEnumerable<IStringMapping> Mappings => _mappings;
 
         public bool HasMappingFor(string input)
         {
-            foreach (var mapping in Mappings)
-                if (mapping.Matches(input))
-                    return true;
-
-            return false;
+            return Mappings.Any(mapping => mapping.Matches(input));
         }
 
         public IStringMapping GetFirstMatchingMappingFor(string input)
         {
-            foreach (var mapping in Mappings)
-                if (mapping.Matches(input))
-                    return mapping;
-
-            return null;
+            return Mappings.FirstOrDefault(mapping => mapping.Matches(input));
         }
 
         public IEnumerable<IStringMapping> GetAllMatchingMappingsFor(string input)
@@ -42,11 +34,7 @@ namespace Bifrost.Utils
 
         public string Resolve(string input)
         {
-            var mapping = GetFirstMatchingMappingFor(input);
-            if (mapping != null)
-                return mapping.Resolve(input);
-
-            return string.Empty;
+            return GetFirstMatchingMappingFor(input)?.Resolve(input);
         }
 
         public void AddMapping(string format, string mappedFormat)


### PR DESCRIPTION
Some code cleanup, including consistent ordering on generated proxies.

Original issue: ProCoSys/Bifrost#45

(To get CommandSecurityProxies, reference Bifrost/Security instead of Bifrost/Application.)